### PR TITLE
Server thread

### DIFF
--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -15,6 +15,7 @@ from ..api import discover, Data
 from ..expr import Expr, Symbol, Selection, Broadcast, Symbol
 from ..expr.parser import exprify
 from .. import expr
+from ..utils import example, FunctionRunner
 
 from ..compatibility import map
 from datashape import Mono
@@ -61,8 +62,32 @@ class Server(object):
         return value
 
     def run(self, *args, **kwargs):
+        """ Start serving data
+
+        Parameters
+        ----------
+
+        host : str
+            IPs to allow.  Defaults to localhost.  Set to '0.0.0.0' for public.
+        port : int
+            The port on which to serve the data, defaults to 6363
+        separate_thread : bool
+            Optionally run the server in a separate thread.  Returns thread
+            object
+
+        All other args and keyword args are passed through to the Flask
+        application.  See ``self.app.run`` for more details
+        """
+        port=int - a specific port to use, defaults to 6363
+        separate_thread=bool - Specify true
+
         port = kwargs.pop('port', DEFAULT_PORT)
         self.port = port
+        separate_thread = kwargs.pop('separate_thread', False)
+        if separate_thread:
+            thread = FunctionRunner(self.run, *args, **kwargs)
+            thread.start()
+            return thread
         try:
             self.app.run(*args, port=port, **kwargs)
         except socket.error:

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -78,9 +78,6 @@ class Server(object):
         All other args and keyword args are passed through to the Flask
         application.  See ``self.app.run`` for more details
         """
-        port=int - a specific port to use, defaults to 6363
-        separate_thread=bool - Specify true
-
         port = kwargs.pop('port', DEFAULT_PORT)
         self.port = port
         separate_thread = kwargs.pop('separate_thread', False)

--- a/blaze/server/tests/test_server.py
+++ b/blaze/server/tests/test_server.py
@@ -6,6 +6,7 @@ from flask import json
 from datetime import datetime
 from dynd import nd
 from pandas import DataFrame
+import requests
 
 from blaze.utils import example
 from blaze import discover, Symbol, by, CSV, compute, join, into
@@ -205,3 +206,16 @@ def test_multi_expression_compute():
     expected = compute(expr, {a: accounts, c: cities})
 
     assert list(map(tuple, result))== into(list, expected)
+
+
+def test_run_in_thread():
+    s = Server({'a': [1, 2, 3]})
+    thread = s.run(separate_thread=True)
+
+    try:
+        response = requests.get('http://localhost:%d/datasets.json' % s.port)
+        assert response.ok
+
+        assert json.loads(response.content) == {'a': '3 * int64'}
+    finally:
+        thread._Thread__stop()

--- a/blaze/server/tests/test_server.py
+++ b/blaze/server/tests/test_server.py
@@ -8,7 +8,7 @@ from dynd import nd
 from pandas import DataFrame
 import requests
 
-from blaze.utils import example
+from blaze.utils import example, thread_stop
 from blaze import discover, Symbol, by, CSV, compute, join, into
 from blaze.server.server import Server, to_tree, from_tree
 from blaze.server.index import emit_index
@@ -218,4 +218,4 @@ def test_run_in_thread():
 
         assert json.loads(response.content) == {'a': '3 * int64'}
     finally:
-        thread._Thread__stop()
+        thread_stop(thread)

--- a/blaze/tests/test_utils.py
+++ b/blaze/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
+import time
 
-from blaze.utils import tmpfile
+from blaze.utils import tmpfile, alongside
 
 
 def test_tmpfile():
@@ -11,3 +12,16 @@ def test_tmpfile():
             assert f != g
 
     assert not os.path.exists(f)
+
+
+def test_alongside():
+    x = [0]
+
+    def incx():
+        x[0] = x[0] + 1
+
+    with alongside(time.sleep, 100000):
+        with alongside(incx):
+            pass
+
+    assert x[0] == 1

--- a/blaze/utils.py
+++ b/blaze/utils.py
@@ -8,6 +8,7 @@ from threading import Thread
 from itertools import islice
 from contextlib import contextmanager
 from collections import Iterator
+import sys
 
 import psutil
 import numpy as np
@@ -225,10 +226,19 @@ def alongside(func, *args, **kwargs):
 
     """
     t = FunctionRunner(func, *args, **kwargs)
+    t.daemon = True
 
     t.start()
     try:
         yield
 
     finally:
-        t._Thread__stop()
+        thread_stop(t)
+
+if sys.version_info[0] == 2:
+    def thread_stop(thread):
+        thread._Thread__stop()
+elif sys.version_info[0] == 3:
+    def thread_stop(thread):
+        thread._reset_internal_locks(False)
+        thread._stop()


### PR DESCRIPTION
Servers don't have to block

```Python
In [1]: from blaze import Server

In [2]: server = Server({})

In [3]: server.run(separate_thread=True)
Out[3]: <FunctionRunner(Thread-1, started 139788731410176)>
 * Running on http://127.0.0.1:6363/

In [4]: # Control returned
```