### PR TITLE
Split fails on branching expressions

### DIFF
--- a/blaze/expr/tests/test_split.py
+++ b/blaze/expr/tests/test_split.py
@@ -333,3 +333,12 @@ def test_splittable_apply():
             chunk.amount.apply(f, 'var * int', splittable=True))
 
     assert agg_expr.isidentical(agg)
+
+
+def test_elemwise_with_multiple_paths():
+    s = symbol('s', 'var * {x: int, y: int, z: int}')
+    expr = s.x.sum() / s.y.sum()
+
+    (chunk, chunk_expr), (agg, agg_expr) = split(s, expr)
+    assert chunk_expr.isidentical(summary(x=chunk.x.sum(), y=chunk.y.sum()))
+    assert agg_expr.isidentical(agg.x / agg.y)


### PR DESCRIPTION
Expressions like the following need to be turned into a single line expression before using split.

    s = symbol('s', 'var * {x: int, y: int, z: int}')
    expr = s.x.sum() / s.y.sum()

E.g. this looks like the following

```
  | 
 / \
 \ /
  | 
```

Making split handle this well is probably hard.  It's likely easier to make a new function that remove intermediate branches to expressions that look like the following

```
| 
|
|
|
```

This is possible with expressions like `Summary` and `Broadcast`.  It might be possible to roll this into the work of broadcast optimize.