### PR TITLE
Compute on pandas.HDFStore

### DIFF
--- a/blaze/__init__.py
+++ b/blaze/__init__.py
@@ -57,6 +57,10 @@ try:
 except ImportError:
     pass
 try:
+    from .compute.hdfstore import *
+except ImportError:
+    pass
+try:
     from .compute.pytables import *
 except ImportError:
     pass

--- a/blaze/compute/hdfstore.py
+++ b/blaze/compute/hdfstore.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import, division, print_function
+
+from .core import pre_compute
+from ..expr import Expr, Field
+from ..dispatch import dispatch
+from into import into, chunks
+import pandas as pd
+
+@dispatch(Expr, pd.io.pytables.AppendableFrameTable)
+def pre_compute(expr, data, **kwargs):
+    return into(chunks(pd.DataFrame), data, **kwargs)
+
+
+@dispatch(Expr, pd.io.pytables.Fixed)
+def pre_compute(expr, data, **kwargs):
+    return into(pd.DataFrame, data, **kwargs)
+
+
+@dispatch(Field, pd.HDFStore)
+def compute_up(expr, data, **kwargs):
+    return data.get_storer('/%s' % expr._name)

--- a/blaze/compute/hdfstore.py
+++ b/blaze/compute/hdfstore.py
@@ -18,4 +18,21 @@ def pre_compute(expr, data, **kwargs):
 
 @dispatch(Field, pd.HDFStore)
 def compute_up(expr, data, **kwargs):
-    return data.get_storer('/%s' % expr._name)
+    key = '/' + expr._name
+    if key in data.keys():
+        return data.get_storer(key)
+    else:
+        return HDFGroup(data, key)
+
+
+from collections import namedtuple
+HDFGroup = namedtuple('HDFGroup', 'parent,datapath')
+
+
+@dispatch(Field, HDFGroup)
+def compute_up(expr, data, **kwargs):
+    key = data.datapath + '/' + expr._name
+    if key in data.parent.keys():
+        return data.parent.get_storer(key)
+    else:
+        return HDFGroup(data.parent, key)

--- a/blaze/compute/tests/test_hdfstore.py
+++ b/blaze/compute/tests/test_hdfstore.py
@@ -4,6 +4,7 @@ from blaze import symbol, discover, compute
 import pandas as pd
 from datetime import datetime
 from into import Chunks, resource, into
+from blaze.compatibility import skipif, PY3
 
 
 df = pd.DataFrame([['a', 1, 10., datetime(2000, 1, 1)],
@@ -13,10 +14,11 @@ df = pd.DataFrame([['a', 1, 10., datetime(2000, 1, 1)],
                    columns=['name', 'a', 'b', 'time'])
 
 
+@skipif(PY3, reason="https://github.com/pydata/pandas/issues/9219")
 def test_hdfstore():
     with tmpfile('.hdf5') as fn:
-        df.to_hdf(fn, 'fixed')
-        df.to_hdf(fn, 'appendable', append=True)
+        df.to_hdf(fn, '/appendable', format='table')
+        df.to_hdf(fn, '/fixed')
 
         hdf = resource('hdfstore://%s' % fn)
         s = symbol('s', discover(hdf))

--- a/blaze/compute/tests/test_hdfstore.py
+++ b/blaze/compute/tests/test_hdfstore.py
@@ -1,0 +1,32 @@
+from blaze.compute.hdfstore import *
+from blaze.utils import tmpfile
+from blaze import symbol, discover, compute
+import pandas as pd
+from datetime import datetime
+from into import Chunks, resource, into
+
+
+df = pd.DataFrame([['a', 1, 10., datetime(2000, 1, 1)],
+                   ['ab', 2, 20., datetime(2000, 2, 2)],
+                   ['abc', 3, 30., datetime(2000, 3, 3)],
+                   ['abcd', 4, 40., datetime(2000, 4, 4)]],
+                   columns=['name', 'a', 'b', 'time'])
+
+
+def test_hdfstore():
+    with tmpfile('.hdf5') as fn:
+        df.to_hdf(fn, 'fixed')
+        df.to_hdf(fn, 'appendable', append=True)
+
+        hdf = resource('hdfstore://%s' % fn)
+        s = symbol('s', discover(hdf))
+
+        assert isinstance(compute(s.fixed, hdf),
+                          (pd.DataFrame, pd.io.pytables.Fixed))
+        assert isinstance(compute(s.appendable, hdf),
+                          (pd.io.pytables.AppendableFrameTable, Chunks))
+
+        s = symbol('s', discover(df))
+        f = resource('hdfstore://%s::/fixed' % fn)
+        a = resource('hdfstore://%s::/appendable' % fn)
+        assert isinstance(pre_compute(s, a), Chunks)

--- a/blaze/compute/tests/test_hdfstore.py
+++ b/blaze/compute/tests/test_hdfstore.py
@@ -31,6 +31,11 @@ def test_hdfstore():
         a = resource('hdfstore://%s::/appendable' % fn)
         assert isinstance(pre_compute(s, a), Chunks)
 
+        hdf.close()
+        f.parent.close()
+        a.parent.close()
+
+
 
 def test_groups():
     with tmpfile('.hdf5') as fn:
@@ -42,3 +47,5 @@ def test_groups():
         s = symbol('s', discover(hdf))
 
         assert list(compute(s.data.fixed, hdf).a) == [1, 2, 3, 4]
+
+        hdf.close()

--- a/blaze/compute/tests/test_hdfstore.py
+++ b/blaze/compute/tests/test_hdfstore.py
@@ -30,3 +30,15 @@ def test_hdfstore():
         f = resource('hdfstore://%s::/fixed' % fn)
         a = resource('hdfstore://%s::/appendable' % fn)
         assert isinstance(pre_compute(s, a), Chunks)
+
+
+def test_groups():
+    with tmpfile('.hdf5') as fn:
+        df.to_hdf(fn, '/data/fixed')
+
+        hdf = resource('hdfstore://%s' % fn)
+        assert discover(hdf) == discover({'data': {'fixed': df}})
+
+        s = symbol('s', discover(hdf))
+
+        assert list(compute(s.data.fixed, hdf).a) == [1, 2, 3, 4]

--- a/blaze/tests/test_pytables.py
+++ b/blaze/tests/test_pytables.py
@@ -6,7 +6,7 @@ from toolz import first
 from blaze import into
 from blaze.utils import tmpfile
 from blaze.compatibility import xfail
-from blaze import PyTables, discover, Data
+from blaze import PyTables, discover
 
 
 tb = pytest.importorskip('tables')
@@ -151,15 +151,6 @@ class TestPyTablesLight(object):
         lhs, rhs = map(discover, (t, dt_data))
         t._v_file.close()
         assert lhs == rhs
-
-
-    def test_context_manager(self, dt_tb, dt_data):
-        """ check the context manager auto-closes the resources """
-
-        with Data("{0}::dt".format(dt_tb)) as t:
-            f = first(t._resources().values())
-            assert f.isopen
-        assert not f.isopen
 
     def test_no_extra_files_around(self, dt_tb):
         """ check the context manager auto-closes the resources """


### PR DESCRIPTION
Support `pandas.HDFStore` like `h5py.FIle`.  

```Python
In [1]: import pandas as pd

In [2]: from datetime import datetime

In [3]: df = pd.DataFrame([[1, 10., datetime(2000, 1, 1)],
                   [2, 20., datetime(2000, 2, 2)],
                   [3, 30., datetime(2000, 3, 3)],
                   [4, 40., datetime(2000, 4, 4)]],
                   columns=['a', 'b', 'time'])

In [4]: df.to_hdf('foo.hdf5', '/my/data/x')

In [5]: from blaze import Data

In [6]: d = Data('hdfstore://foo.hdf5')

In [7]: d
Out[7]: 
Data:       <class 'pandas.io.pytables.HDFStore'>
File path: foo.hdf5
/my/data/x            frame        (shape->[4,3])
DataShape:  {my: {data: {x: 4 * {a: int64, b: float64, time: datetime}}}}

In [8]: d.my.data.x
Out[8]: 
   a   b       time
0  1  10 2000-01-01
1  2  20 2000-02-02
2  3  30 2000-03-03
3  4  40 2000-04-04

In [9]: d.my.data.x.b.sum()
Out[9]: 100.0
```