### PR TITLE
PR to cleanup a few things in pandas

### DIFF
--- a/blaze/compute/tests/test_bcolz_compute.py
+++ b/blaze/compute/tests/test_bcolz_compute.py
@@ -1,15 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
-from datashape import discover, dshape
 bcolz = pytest.importorskip('bcolz')
+
+from datashape import discover, dshape
 
 import numpy as np
 
 from into import into
-from blaze.compute.bcolz import chunks
 from blaze.expr import symbol
 from blaze.compute.core import compute, pre_compute
+from blaze.compute.bcolz import get_chunksize
 
 
 b = bcolz.ctable(np.array([(1, 1., np.datetime64('2010-01-01')),
@@ -30,11 +31,6 @@ bo = bcolz.ctable(np.array([(1, 1.), (2, 2.), (3, np.nan)],
 def test_discover():
     assert discover(b) == dshape('3 * {a: int64, b: float64, date: date}')
     assert discover(b['a']) == dshape('3 * int64')
-
-
-def test_chunks():
-    assert len(list(chunks(b, chunksize=2))) == 2
-    assert (next(chunks(b, chunksize=2)) == into(np.ndarray, b)[:2]).all()
 
 
 def test_reductions():
@@ -81,15 +77,16 @@ def test_selection_head():
              dshape=ds)
     t = symbol('t', ds)
 
-    assert compute((t.a < t.b).all(), b) == True
+    # numpy reductions return numpy scalars
+    assert compute((t.a < t.b).all(), b).item() is True
     assert list(compute(t[t.a < t.b].a.head(10), b)) == list(range(10))
     assert list(compute(t[t.a > t.b].a.head(10), b)) == []
 
     assert into([], compute(t[t.a + t.b > t.c], b)) == [(0, 1, 0),
                                                         (1, 2, 1),
                                                         (2, 3, 4)]
-    assert len(compute(t[t.a + t.b > t.c].head(10), b)) # non-empty
-    assert len(compute(t[t.a + t.b < t.c].head(10), b)) # non-empty
+    assert len(compute(t[t.a + t.b > t.c].head(10), b))  # non-empty
+    assert len(compute(t[t.a + t.b < t.c].head(10), b))  # non-empty
 
 
 def test_selection_isnan():
@@ -101,7 +98,8 @@ def test_selection_isnan():
     for n in b.dtype.names:
         assert np.isclose(lhs[n], rhs[n], equal_nan=True).all()
         assert np.isclose(compute(t[~t.b.isnan()], b)[n],
-                          np.array([(1, 1.0), (np.nan, 2.0)], dtype=b.dtype)[n],
+                          np.array(
+                              [(1, 1.0), (np.nan, 2.0)], dtype=b.dtype)[n],
                           equal_nan=True).all()
 
 
@@ -126,7 +124,8 @@ def test_nelements():
     assert compute(t.nelements(), b) == len(b)
 
 
-def dont_test_pre_compute(): # This is no longer desired.  Handled by compute_up
+# This is no longer desired. Handled by compute_up
+def dont_test_pre_compute():
     b = bcolz.ctable(np.array([(1, 1., 10.), (2, 2., 20.), (3, 3., 30.)],
                               dtype=[('a', 'i8'), ('b', 'f8'), ('c', 'f8')]))
 
@@ -137,10 +136,7 @@ def dont_test_pre_compute(): # This is no longer desired.  Handled by compute_up
 
 
 def eq(a, b):
-    c = a == b
-    if isinstance(c, np.ndarray):
-        c = c.all()
-    return c
+    return np.array_equal(a, b)
 
 
 def test_unicode_field_names():
@@ -148,7 +144,12 @@ def test_unicode_field_names():
                               dtype=[('a', 'i8'), ('b', 'f8'), ('c', 'f8')]))
     s = symbol('s', discover(b))
 
-    assert eq(compute(s[u'a'], b)[:],
-              compute(s['a'],  b)[:])
-    assert eq(compute(s[[u'a', u'c']], b)[:],
-              compute(s[['a', 'c']],  b)[:])
+    assert eq(compute(s[u'a'], b)[:], compute(s['a'], b)[:])
+    assert eq(compute(s[[u'a', u'c']], b)[:], compute(s[['a', 'c']], b)[:])
+
+
+def test_chunksize_inference():
+    b = bcolz.ctable(np.array([(1, 1., 10.), (2, 2., 20.), (3, 3., 30.)],
+                              dtype=[('a', 'i8'), ('b', 'f8'), ('c', 'f8')]),
+                     chunklen=2)
+    assert get_chunksize(b) == 2

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -481,12 +481,11 @@ def test_summary_by_first():
     assert result == df.amount.iloc[0]
 
 
-@pytest.mark.xfail(reason="reduction assumed to be at the end")
 def test_summary_by_reduction_arithmetic():
     expr = by(t.name, summary(count=t.id.count(), sum=t.amount.sum() + 1))
     result = compute(expr, df)
     expected = DataFrame([['Alice', 2, 151],
-                          ['Bob', 1, 202]], columns=['name', 'count', 'sum'])
+                          ['Bob', 1, 201]], columns=['name', 'count', 'sum'])
     tm.assert_frame_equal(result, expected)
 
 

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -337,13 +337,6 @@ ts = pd.date_range('now', periods=10).to_series().reset_index(drop=True)
 tframe = DataFrame({'timestamp': ts})
 
 
-def test_map_with_rename():
-    t = symbol('s', discover(tframe))
-    result = t.timestamp.map(lambda x: x.date(), schema='{date: datetime}')
-    renamed = result.relabel({'timestamp': 'date'})
-    assert renamed.fields == ['date']
-
-
 def test_map_column():
     inc = lambda x: x + 1
     result = compute(t['amount'].map(inc, 'int'), df)

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -344,14 +344,6 @@ def test_map_with_rename():
     assert renamed.fields == ['date']
 
 
-@pytest.mark.xfail(reason="Should this?  This seems odd but vacuously valid")
-def test_multiple_renames_on_series_fails():
-    t = symbol('s', discover(tframe))
-    expr = t.timestamp.relabel({'timestamp': 'date', 'hello': 'world'})
-    with pytest.raises(ValueError):
-        compute(expr, tframe)
-
-
 def test_map_column():
     inc = lambda x: x + 1
     result = compute(t['amount'].map(inc, 'int'), df)

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -4,14 +4,15 @@ import pytest
 
 from datetime import datetime
 import pandas as pd
+import pandas.util.testing as tm
 import numpy as np
 from pandas import DataFrame, Series
 
 from blaze.compute.core import compute
 from blaze import dshape, discover, transform
 from blaze.expr import symbol, join, by, summary, Distinct, shape
-from blaze.expr import (merge, exp, mean, count, nunique, Apply, sum,
-                        min, max, any, all, Projection, var, std)
+from blaze.expr import (merge, exp, mean, count, nunique, sum, min, max, any,
+                        all, var, std)
 from blaze.compatibility import builtins, xfail
 
 t = symbol('t', 'var * {name: string, amount: int, id: int}')
@@ -22,7 +23,8 @@ df = DataFrame([['Alice', 100, 1],
                 ['Alice', 50, 3]], columns=['name', 'amount', 'id'])
 
 
-tbig = symbol('tbig', 'var * {name: string, sex: string[1], amount: int, id: int}')
+tbig = symbol('tbig',
+              'var * {name: string, sex: string[1], amount: int, id: int}')
 
 dfbig = DataFrame([['Alice', 'F', 100, 1],
                    ['Alice', 'F', 100, 3],
@@ -35,7 +37,8 @@ dfbig = DataFrame([['Alice', 'F', 100, 1],
 def df_all(a_df, b_df):
     """Checks if two dataframes have the same columns
 
-    This method doesn't check the index which can be manipulated during operations.
+    This method doesn't check the index which can be manipulated during
+    operations.
     """
     assert all(a_df.columns == b_df.columns)
     for col in a_df.columns:
@@ -47,56 +50,57 @@ def test_series_columnwise():
     s = Series([1, 2, 3], name='a')
     t = symbol('t', 'var * {a: int64}')
     result = compute(t.a + 1, s)
-    pd.util.testing.assert_series_equal(s + 1, result)
+    tm.assert_series_equal(s + 1, result)
 
 
 def test_symbol():
-    assert str(compute(t, df)) == str(df)
+    tm.assert_frame_equal(compute(t, df), df)
 
 
 def test_projection():
-    assert str(compute(t['name'], df)) == str(df['name'])
+    tm.assert_frame_equal(compute(t[['name', 'id']], df),
+                          df[['name', 'id']])
 
 
 def test_eq():
-    assert ((compute(t['amount'] == 100, df))
-             == (df['amount'] == 100)).all()
+    tm.assert_series_equal(compute(t['amount'] == 100, df),
+                           df['amount'] == 100)
 
 
 def test_selection():
-    assert str(compute(t[t['amount'] == 0], df)) == str(df[df['amount'] == 0])
-    assert str(compute(t[t['amount'] > 150], df)) == str(df[df['amount'] > 150])
+    tm.assert_frame_equal(compute(t[t['amount'] == 0], df),
+                          df[df['amount'] == 0])
+    tm.assert_frame_equal(compute(t[t['amount'] > 150], df),
+                          df[df['amount'] > 150])
 
 
 def test_arithmetic():
-    assert str(compute(t['amount'] + t['id'], df)) == \
-                str(df.amount + df.id)
-    assert str(compute(t['amount'] * t['id'], df)) == \
-                str(df.amount * df.id)
-    assert str(compute(t['amount'] % t['id'], df)) == \
-                str(df.amount % df.id)
+    tm.assert_series_equal(compute(t['amount'] + t['id'], df),
+                           df.amount + df.id)
+    tm.assert_series_equal(compute(t['amount'] * t['id'], df),
+                           df.amount * df.id)
+    tm.assert_series_equal(compute(t['amount'] % t['id'], df),
+                           df.amount % df.id)
 
 
 def test_join():
-    left = DataFrame([['Alice', 100], ['Bob', 200]], columns=['name', 'amount'])
+    left = DataFrame(
+        [['Alice', 100], ['Bob', 200]], columns=['name', 'amount'])
     right = DataFrame([['Alice', 1], ['Bob', 2]], columns=['name', 'id'])
 
-    L = symbol('L', 'var * {name: string, amount: int}')
-    R = symbol('R', 'var * {name: string, id: int}')
-    joined = join(L, R, 'name')
+    lsym = symbol('L', 'var * {name: string, amount: int}')
+    rsym = symbol('R', 'var * {name: string, id: int}')
+    joined = join(lsym, rsym, 'name')
 
     assert (dshape(joined.schema) ==
             dshape('{name: string, amount: int, id: int}'))
 
-    result = compute(joined, {L: left, R: right})
+    result = compute(joined, {lsym: left, rsym: right})
 
     expected = DataFrame([['Alice', 100, 1], ['Bob', 200, 2]],
                          columns=['name', 'amount', 'id'])
 
-    print(result)
-    print(expected)
-    assert str(result) == str(expected)
-
+    tm.assert_frame_equal(result, expected)
     assert list(result.columns) == list(joined.fields)
 
 
@@ -110,21 +114,21 @@ def test_multi_column_join():
              (1, 3, 150)]
     right = DataFrame(right, columns=['x', 'y', 'w'])
 
-    L = symbol('L', 'var * {x: int, y: int, z: int}')
-    R = symbol('R', 'var * {x: int, y: int, w: int}')
+    lsym = symbol('lsym', 'var * {x: int, y: int, z: int}')
+    rsym = symbol('rsym', 'var * {x: int, y: int, w: int}')
 
-    j = join(L, R, ['x', 'y'])
+    j = join(lsym, rsym, ['x', 'y'])
 
     expected = [(1, 2, 3, 30),
                 (1, 3, 5, 50),
                 (1, 3, 5, 150)]
     expected = DataFrame(expected, columns=['x', 'y', 'z', 'w'])
 
-    result = compute(j, {L: left, R: right})
+    result = compute(j, {lsym: left, rsym: right})
 
     print(result)
 
-    assert str(result) == str(expected)
+    tm.assert_frame_equal(result, expected)
     assert list(result.columns) == list(j.fields)
 
 
@@ -133,12 +137,14 @@ def test_unary_op():
 
 
 def test_neg():
-    assert (compute(-t['amount'], df) == -df['amount']).all()
+    tm.assert_series_equal(compute(-t['amount'], df),
+                           -df['amount'])
 
 
 @xfail(reason='Projection does not support arithmetic')
 def test_neg_projection():
-    assert (compute(-t[['amount', 'id']], df) == -df[['amount', 'id']]).all()
+    tm.assert_series_equal(compute(-t[['amount', 'id']], df),
+                           -df[['amount', 'id']])
 
 
 def test_columns_series():
@@ -147,15 +153,15 @@ def test_columns_series():
 
 
 def test_reductions():
-    assert compute(mean(t['amount']), df) == 350./3
+    assert compute(mean(t['amount']), df) == 350 / 3
     assert compute(count(t['amount']), df) == 3
     assert compute(sum(t['amount']), df) == 100 + 200 + 50
     assert compute(min(t['amount']), df) == 50
     assert compute(max(t['amount']), df) == 200
     assert compute(nunique(t['amount']), df) == 3
     assert compute(nunique(t['name']), df) == 2
-    assert compute(any(t['amount'] > 150), df) == True
-    assert compute(any(t['amount'] > 250), df) == False
+    assert compute(any(t['amount'] > 150), df) is True
+    assert compute(any(t['amount'] > 250), df) is False
     assert compute(var(t['amount']), df) == df.amount.var(ddof=0)
     assert compute(var(t['amount'], unbiased=True), df) == df.amount.var()
     assert compute(std(t['amount']), df) == df.amount.std(ddof=0)
@@ -186,7 +192,7 @@ def test_distinct():
                           ['Drew', 'M', 100, 5],
                           ['Drew', 'M', 200, 5],
                           ['Drew', 'M', 200, 5]],
-                          columns=['name', 'sex', 'amount', 'id'])
+                         columns=['name', 'sex', 'amount', 'id'])
     d_t = Distinct(tbig)
     d_df = compute(d_t, dftoobig)
     assert df_all(d_df, dfbig)
@@ -198,19 +204,19 @@ def test_by_one():
     result = compute(by(t['name'], total=t['amount'].sum()), df)
     expected = df.groupby('name')['amount'].sum().reset_index()
     expected.columns = ['name', 'total']
-
-    assert str(result) == str(expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_by_two():
-    result = compute(by(tbig[['name', 'sex']], total=sum(tbig['amount'])), dfbig)
+    result = compute(by(tbig[['name', 'sex']],
+                        total=sum(tbig['amount'])), dfbig)
 
     expected = DataFrame([['Alice', 'F', 200],
-                          ['Drew',  'F', 100],
-                          ['Drew',  'M', 300]],
-                          columns=['name', 'sex', 'total'])
+                          ['Drew', 'F', 100],
+                          ['Drew', 'M', 300]],
+                         columns=['name', 'sex', 'total'])
 
-    assert str(result) == str(expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_by_three():
@@ -220,13 +226,11 @@ def test_by_three():
 
     result = compute(expr, dfbig)
 
-    groups = dfbig.groupby(['name', 'sex'])
     expected = DataFrame([['Alice', 'F', 204],
                           ['Drew', 'F', 104],
                           ['Drew', 'M', 310]], columns=['name', 'sex', 'total'])
     expected.columns = expr.fields
-
-    assert str(result) == str(expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_by_four():
@@ -237,14 +241,14 @@ def test_by_four():
     expected = DataFrame([['F', 100],
                           ['M', 200]], columns=['sex', 'max'])
 
-    assert str(result) == str(expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_join_by_arcs():
     df_idx = DataFrame([['A', 1],
                         ['B', 2],
                         ['C', 3]],
-                      columns=['name', 'node_id'])
+                       columns=['name', 'node_id'])
 
     df_arc = DataFrame([[1, 3],
                         [2, 3],
@@ -259,25 +263,28 @@ def test_join_by_arcs():
 
     want = by(joined['name'], count=joined['node_id'].count())
 
-    result = compute(want, {t_arc: df_arc, t_idx:df_idx})
+    result = compute(want, {t_arc: df_arc, t_idx: df_idx})
 
     result_pandas = pd.merge(df_arc, df_idx, on='node_id')
 
-    expected = result_pandas.groupby('name')['node_id'].count().reset_index()
-    assert str(result.values) == str(expected.values)
+    gb = result_pandas.groupby('name')
+    expected = gb.node_id.count().reset_index().rename(columns={
+                                                       'node_id': 'count'
+                                                       })
+
+    tm.assert_frame_equal(result, expected)
     assert list(result.columns) == ['name', 'count']
 
 
 def test_sort():
-    print(str(compute(t.sort('amount'), df)))
-    print(str(df.sort('amount')))
-    assert str(compute(t.sort('amount'), df)) == str(df.sort('amount'))
+    tm.assert_frame_equal(compute(t.sort('amount'), df),
+                          df.sort('amount'))
 
-    assert str(compute(t.sort('amount', ascending=True), df)) == \
-            str(df.sort('amount', ascending=True))
+    tm.assert_frame_equal(compute(t.sort('amount', ascending=True), df),
+                          df.sort('amount', ascending=True))
 
-    assert str(compute(t.sort(['amount', 'id']), df)) == \
-            str(df.sort(['amount', 'id']))
+    tm.assert_frame_equal(compute(t.sort(['amount', 'id']), df),
+                          df.sort(['amount', 'id']))
 
 
 def test_sort_on_series_no_warning(recwarn):
@@ -285,38 +292,40 @@ def test_sort_on_series_no_warning(recwarn):
 
     recwarn.clear()
 
-    assert str(compute(t['amount'].sort('amount'), df)) ==\
-            str(expected)
+    tm.assert_series_equal(compute(t['amount'].sort('amount'), df),
+                           expected)
 
     # raises as assertion error if no warning occurs, same thing for below
     with pytest.raises(AssertionError):
         assert recwarn.pop(FutureWarning)
 
-    assert str(compute(t['amount'].sort(), df)) ==\
-            str(expected)
+    tm.assert_series_equal(compute(t['amount'].sort(), df),
+                           expected)
     with pytest.raises(AssertionError):
         assert recwarn.pop(FutureWarning)
+
 
 def test_field_on_series():
     expr = symbol('s', 'var * int')
     data = Series([1, 2, 3, 4], name='s')
-    assert str(compute(expr.s, data)) == str(data)
+    tm.assert_series_equal(compute(expr.s, data), data)
 
 
 def test_head():
-    assert str(compute(t.head(1), df)) == str(df.head(1))
+    tm.assert_frame_equal(compute(t.head(1), df), df.head(1))
 
 
 def test_label():
     expected = df['amount'] * 10
     expected.name = 'foo'
-    assert str(compute((t['amount'] * 10).label('foo'), df)) == \
-            str(expected)
+    tm.assert_series_equal(compute((t['amount'] * 10).label('foo'), df),
+                           expected)
 
 
 def test_relabel():
     result = compute(t.relabel({'name': 'NAME', 'id': 'ID'}), df)
-    assert list(result.columns) == ['NAME', 'amount', 'ID']
+    expected = df.rename(columns={'name': 'NAME', 'id': 'ID'})
+    tm.assert_frame_equal(result, expected)
 
 
 def test_relabel_series():
@@ -347,32 +356,29 @@ def test_map_column():
     inc = lambda x: x + 1
     result = compute(t['amount'].map(inc, 'int'), df)
     expected = df['amount'] + 1
-    assert str(result) == str(expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_map():
     f = lambda _, amt, id: amt + id
     result = compute(t.map(f, 'real'), df)
     expected = df['amount'] + df['id']
-    assert str(result) == str(expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_apply_column():
     result = compute(t.amount.apply(np.sum, 'real'), df)
     expected = np.sum(df['amount'])
-
-    assert str(result) == str(expected)
+    assert result == expected
 
     result = compute(t.amount.apply(builtins.sum, 'real'), df)
     expected = builtins.sum(df['amount'])
-
-    assert str(result) == str(expected)
+    assert result == expected
 
 
 def test_apply():
     result = compute(t.apply(str, 'string'), df)
     expected = str(df)
-
     assert result == expected
 
 
@@ -386,8 +392,7 @@ def test_merge():
                          columns=['name', 'new'])
 
     result = compute(expr, df)
-
-    assert str(result) == str(expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_by_nunique():
@@ -395,13 +400,14 @@ def test_by_nunique():
     expected = DataFrame([['Alice', 2], ['Bob', 1]],
                          columns=['name', 'count'])
 
-    assert str(result) == str(expected)
+    tm.assert_frame_equal(result, expected)
 
 
 def test_selection_out_of_order():
     expr = t['name'][t['amount'] < 100]
-
-    assert str(compute(expr, df)) == str(df['name'][df['amount'] < 100])
+    expected = df.loc[df.amount < 100, 'name']
+    result = compute(expr, df)
+    tm.assert_series_equal(result, expected)
 
 
 def test_outer_join():
@@ -416,69 +422,69 @@ def test_outer_join():
              ('Moscow', 4)]
     right = DataFrame(right, columns=['city', 'id'])
 
-    L = symbol('L', 'var * {id: int, name: string, amount: real}')
-    R = symbol('R', 'var * {city: string, id: int}')
+    lsym = symbol('lsym', 'var * {id: int, name: string, amount: real}')
+    rsym = symbol('rsym', 'var * {city: string, id: int}')
 
     convert = lambda df: set(df.to_records(index=False).tolist())
 
-    assert convert(compute(join(L, R), {L: left, R: right})) == set(
-            [(1, 'Alice', 100, 'NYC'),
-             (1, 'Alice', 100, 'Boston'),
-             (4, 'Dennis', 400, 'Moscow')])
+    assert (convert(compute(join(lsym, rsym), {lsym: left, rsym: right})) ==
+            set([(1, 'Alice', 100, 'NYC'),
+                 (1, 'Alice', 100, 'Boston'),
+                 (4, 'Dennis', 400, 'Moscow')]))
 
-    assert convert(compute(join(L, R, how='left'), {L: left, R: right})) == set(
-            [(1, 'Alice', 100, 'NYC'),
-             (1, 'Alice', 100, 'Boston'),
-             (2, 'Bob', 200, np.nan),
-             (4, 'Dennis', 400, 'Moscow')])
+    assert (convert(compute(join(lsym, rsym, how='left'),
+                            {lsym: left, rsym: right})) ==
+            set([(1, 'Alice', 100, 'NYC'),
+                 (1, 'Alice', 100, 'Boston'),
+                 (2, 'Bob', 200, np.nan),
+                 (4, 'Dennis', 400, 'Moscow')]))
 
-    df = compute(join(L, R, how='right'), {L: left, R: right})
-    expected = DataFrame(
-            [(1., 'Alice', 100., 'NYC'),
-             (1., 'Alice', 100., 'Boston'),
-             (3., np.nan, np.nan, 'LA'),
-             (4., 'Dennis', 400., 'Moscow')],
-            columns=['id', 'name', 'amount', 'city'])
+    df = compute(join(lsym, rsym, how='right'), {lsym: left, rsym: right})
+    expected = DataFrame([(1., 'Alice', 100., 'NYC'),
+                          (1., 'Alice', 100., 'Boston'),
+                          (3., np.nan, np.nan, 'lsymA'),
+                          (4., 'Dennis', 400., 'Moscow')],
+                         columns=['id', 'name', 'amount', 'city'])
 
-    assert str(df.sort('id').to_records(index=False)) ==\
-            str(expected.sort('id').to_records(index=False))
+    result = df.sort('id').to_records(index=False)
+    expected = expected.sort('id').to_records(index=False)
+    np.array_equal(result, expected)
 
-    df = compute(join(L, R, how='outer'), {L: left, R: right})
-    expected = DataFrame(
-            [(1., 'Alice', 100., 'NYC'),
-             (1., 'Alice', 100., 'Boston'),
-             (2., 'Bob', 200., np.nan),
-             (3., np.nan, np.nan, 'LA'),
-             (4., 'Dennis', 400., 'Moscow')],
-            columns=['id', 'name', 'amount', 'city'])
+    df = compute(join(lsym, rsym, how='outer'), {lsym: left, rsym: right})
+    expected = DataFrame([(1., 'Alice', 100., 'NYC'),
+                          (1., 'Alice', 100., 'Boston'),
+                          (2., 'Bob', 200., np.nan),
+                          (3., np.nan, np.nan, 'LA'),
+                          (4., 'Dennis', 400., 'Moscow')],
+                         columns=['id', 'name', 'amount', 'city'])
 
-    assert str(df.sort('id').to_records(index=False)) ==\
-            str(expected.sort('id').to_records(index=False))
+    result = df.sort('id').to_records(index=False)
+    expected = expected.sort('id').to_records(index=False)
+    np.array_equal(result, expected)
 
 
 def test_by_on_same_column():
-    df = pd.DataFrame([[1,2],[1,4],[2,9]], columns=['id', 'value'])
+    df = pd.DataFrame([[1, 2], [1, 4], [2, 9]], columns=['id', 'value'])
     t = symbol('data', 'var * {id: int, value: int}')
 
     gby = by(t['id'], count=t['id'].count())
 
     expected = DataFrame([[1, 2], [2, 1]], columns=['id', 'count'])
-    result = compute(gby, {t:df})
-
-    assert str(result) == str(expected)
+    result = compute(gby, {t: df})
+    tm.assert_frame_equal(result, expected)
 
 
 def test_summary_by():
     expr = by(t.name, summary(count=t.id.count(), sum=t.amount.sum()))
-    assert str(compute(expr, df)) == \
-            str(DataFrame([['Alice', 2, 150],
-                           ['Bob', 1, 200]], columns=['name', 'count', 'sum']))
+    result = compute(expr, df)
+    expected = DataFrame([['Alice', 2, 150],
+                          ['Bob', 1, 200]], columns=['name', 'count', 'sum'])
 
     expr = by(t.name, summary(count=t.id.count(), sum=(t.amount + 1).sum()))
-    assert str(compute(expr, df)) == \
-            str(DataFrame([['Alice', 2, 152],
-                           ['Bob', 1, 201]], columns=['name', 'count', 'sum']))
-
+    result = compute(expr, df)
+    expected = DataFrame([['Alice', 2, 152],
+                          ['Bob', 1, 201]], columns=['name', 'count', 'sum'])
+    tm.assert_frame_equal(result, expected)
 
 
 @pytest.mark.xfail(raises=TypeError,
@@ -493,14 +499,15 @@ def test_summary_by_first():
 @pytest.mark.xfail(reason="reduction assumed to be at the end")
 def test_summary_by_reduction_arithmetic():
     expr = by(t.name, summary(count=t.id.count(), sum=t.amount.sum() + 1))
-    assert str(compute(expr, df)) == \
-            str(DataFrame([['Alice', 2, 151],
-                           ['Bob', 1, 202]], columns=['name', 'count', 'sum']))
+    result = compute(expr, df)
+    expected = DataFrame([['Alice', 2, 151],
+                          ['Bob', 1, 202]], columns=['name', 'count', 'sum'])
+    tm.assert_frame_equal(result, expected)
 
 
 def test_summary():
     expr = summary(count=t.id.count(), sum=t.amount.sum())
-    assert str(compute(expr, df)) == str(Series({'count': 3, 'sum': 350}))
+    tm.assert_series_equal(compute(expr, df), Series({'count': 3, 'sum': 350}))
 
 
 def test_summary_on_series():
@@ -516,7 +523,7 @@ def test_summary_on_series():
 def test_summary_keepdims():
     expr = summary(count=t.id.count(), sum=t.amount.sum(), keepdims=True)
     expected = DataFrame([[3, 350]], columns=['count', 'sum'])
-    assert str(compute(expr, df)) == str(expected)
+    tm.assert_frame_equal(compute(expr, df), expected)
 
 
 def test_dplyr_transform():
@@ -527,7 +534,7 @@ def test_dplyr_transform():
     lhs = compute(expr, df)
     rhs = pd.concat([df, Series(df.timestamp.map(lambda x: x.date()),
                                 name='date').to_frame()], axis=1)
-    assert str(lhs) == str(rhs)
+    tm.assert_frame_equal(lhs, rhs)
 
 
 def test_nested_transform():
@@ -542,7 +549,7 @@ def test_nested_transform():
     result = compute(expr, df)
     df['timestamp'] = df.timestamp.map(datetime.fromtimestamp)
     df['date'] = df.timestamp.map(lambda x: x.date())
-    assert str(result) == str(df)
+    tm.assert_frame_equal(result, df)
 
 
 def test_like():
@@ -552,7 +559,7 @@ def test_like():
                          columns=['name', 'amount', 'id'])
 
     result = compute(expr, df).reset_index(drop=True)
-    assert (result == expected).all().all()
+    tm.assert_frame_equal(result, expected)
 
 
 def test_rowwise_by():
@@ -565,9 +572,7 @@ def test_rowwise_by():
     expected = pd.DataFrame([(5, 300.03), (6, 300)], columns=expr.fields)
 
     result = compute(expr, df)
-    assert expected.index.tolist() == result.index.tolist()
-    assert expected.columns.tolist() == result.columns.tolist()
-    assert expected.values.tolist() == result.values.tolist()
+    tm.assert_frame_equal(result, expected)
 
 
 def test_datetime_access():
@@ -579,24 +584,24 @@ def test_datetime_access():
     t = symbol('t', discover(df))
 
     for attr in ['day', 'month', 'minute', 'second']:
-        assert (compute(getattr(t.when, attr), df) == \
-                Series([1, 1, 1])).all()
+        tm.assert_series_equal(compute(getattr(t.when, attr), df),
+                               Series([1, 1, 1]))
 
 
 def test_frame_slice():
-    assert (compute(t[0], df) == df.iloc[0]).all()
-    assert (compute(t[2], df) == df.iloc[2]).all()
-    assert (compute(t[:2], df) == df.iloc[:2]).all().all()
-    assert (compute(t[1:3], df) == df.iloc[1:3]).all().all()
-    assert (compute(t[1::2], df) == df.iloc[1::2]).all().all()
+    tm.assert_series_equal(compute(t[0], df), df.iloc[0])
+    tm.assert_series_equal(compute(t[2], df), df.iloc[2])
+    tm.assert_frame_equal(compute(t[:2], df), df.iloc[:2])
+    tm.assert_frame_equal(compute(t[1:3], df), df.iloc[1:3])
+    tm.assert_frame_equal(compute(t[1::2], df), df.iloc[1::2])
 
 
 def test_series_slice():
-    assert (compute(t.amount[0], df) == df.amount.iloc[0]).all()
-    assert (compute(t.amount[2], df) == df.amount.iloc[2]).all()
-    assert (compute(t.amount[:2], df) == df.amount.iloc[:2]).all().all()
-    assert (compute(t.amount[1:3], df) == df.amount.iloc[1:3]).all().all()
-    assert (compute(t.amount[1::2], df) == df.amount.iloc[1::2]).all().all()
+    assert compute(t.amount[0], df) == df.amount.iloc[0]
+    assert compute(t.amount[2], df) == df.amount.iloc[2]
+    tm.assert_series_equal(compute(t.amount[:2], df), df.amount.iloc[:2])
+    tm.assert_series_equal(compute(t.amount[1:3], df), df.amount.iloc[1:3])
+    tm.assert_series_equal(compute(t.amount[1::2], df), df.amount.iloc[1::2])
 
 
 def test_nelements():
@@ -608,9 +613,10 @@ def test_datetime_truncation_minutes():
     data = Series(['2000-01-01T12:10:00Z', '2000-06-25T12:35:12Z'],
                   dtype='M8[ns]')
     s = symbol('s', 'var * datetime')
-    assert list(compute(s.truncate(20, 'minutes'), data)) == \
-            list(Series(['2000-01-01T12:00:00Z', '2000-06-25T12:20:00Z'],
-                        dtype='M8[ns]'))
+    result = compute(s.truncate(20, 'minutes'), data)
+    expected = Series(['2000-01-01T12:00:00Z', '2000-06-25T12:20:00Z'],
+                      dtype='M8[ns]')
+    tm.assert_series_equal(result, expected)
 
 
 def test_datetime_truncation_nanoseconds():
@@ -618,28 +624,29 @@ def test_datetime_truncation_nanoseconds():
                    '2000-01-01T12:10:00.000000025'],
                   dtype='M8[ns]')
     s = symbol('s', 'var * datetime')
-    result = Series(['2000-01-01T12:10:00.000000000',
-                     '2000-01-01T12:10:00.000000020'],
-                    dtype='M8[ns]')
-    assert list(compute(s.truncate(nanoseconds=20), data)) == list(result)
+    expected = Series(['2000-01-01T12:10:00.000000000',
+                       '2000-01-01T12:10:00.000000020'],
+                      dtype='M8[ns]')
+    result = compute(s.truncate(nanoseconds=20), data)
+    tm.assert_series_equal(result, expected)
 
 
 def test_datetime_truncation_weeks():
     data = Series(['2000-01-01T12:10:00Z', '2000-06-25T12:35:12Z'],
                   dtype='M8[ns]')
     s = symbol('s', 'var * datetime')
-    assert list(compute(s.truncate(2, 'weeks'), data)) == \
-            list(Series(['1999-12-19', '2000-06-18'],
-                        dtype='M8[ns]'))
+    result = compute(s.truncate(2, 'weeks'), data)
+    expected = Series(['1999-12-19', '2000-06-18'], dtype='M8[ns]')
+    tm.assert_series_equal(result, expected)
 
 
 def test_datetime_truncation_days():
     data = Series(['2000-01-01T12:10:00Z', '2000-06-25T12:35:12Z'],
                   dtype='M8[ns]')
     s = symbol('s', 'var * datetime')
-    assert list(compute(s.truncate(days=3), data)) == \
-            list(Series(['1999-12-31', '2000-06-25'],
-                        dtype='M8[ns]'))
+    result = compute(s.truncate(days=3), data)
+    expected = Series(['1999-12-31', '2000-06-25'], dtype='M8[ns]')
+    tm.assert_series_equal(result, expected)
 
 
 def test_datetime_truncation_same_as_python():
@@ -653,7 +660,11 @@ def test_datetime_truncation_same_as_python():
 def test_complex_group_by():
     expr = by(merge(tbig.amount // 10, tbig.id % 2),
               count=tbig.name.count())
-    compute(expr, dfbig)  # can we do this?
+    result = compute(expr, dfbig)  # can we do this? yes we can!
+    expected = dfbig.groupby([dfbig.amount // 10,
+                              dfbig.id % 2])['name'].count().reset_index()
+    expected = expected.rename(columns={'name': 'count'})
+    tm.assert_frame_equal(result, expected)
 
 
 def test_by_with_complex_summary():

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -463,6 +463,8 @@ def label(expr, lab):
     if expr._name == lab:
         return expr
     return Label(expr, lab)
+
+
 label.__doc__ = Label.__doc__
 
 
@@ -480,7 +482,7 @@ class ReLabel(ElemWise):
     >>> accounts.relabel(not_a_column='definitely_not_a_column')
     Traceback (most recent call last):
         ...
-    ValueError: Cannot relabel non-existent child fields
+    ValueError: Cannot relabel non-existent child fields: {'not_a_column'}
 
     See Also
     --------
@@ -504,8 +506,12 @@ def relabel(child, labels=None, **kwargs):
     labels = labels or dict()
     labels = toolz.merge(labels, kwargs)
     labels = dict((k, v) for k, v in labels.items() if k != v)
-    if not set(labels).issubset(child.fields):
-        raise ValueError("Cannot relabel non-existent child fields")
+    label_keys = set(labels)
+    fields = child.fields
+    if not label_keys.issubset(fields):
+        non_existent_fields = label_keys.difference(fields)
+        raise ValueError("Cannot relabel non-existent child fields: {%s}" %
+                         ', '.join(map(repr, non_existent_fields)))
     if not labels:
         return child
     if isinstance(labels, dict):  # Turn dict into tuples

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -233,8 +233,11 @@ class Symbol(Expr):
 
     Example
     -------
-
     >>> points = symbol('points', '5 * 3 * {x: int, y: int}')
+    >>> points
+    points
+    >>> points.dshape
+    dshape("5 * 3 * {x: int32, y: int32}")
     """
     __slots__ = '_hash', '_name', 'dshape', '_token'
     __inputs__ = ()

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 import toolz
 import datashape
 import functools
+import keyword
+
 from toolz import concat, memoize, partial
 from toolz.curried import map, filter
 import re
@@ -24,22 +26,29 @@ __all__ = ['Expr', 'ElemWise', 'Field', 'Symbol', 'discover', 'Projection',
 _attr_cache = dict()
 
 
-def isvalid_identifier(s):
-    """
+def isvalid_identifier(s, regex=re.compile('^[_a-zA-Z][_a-zA-Z0-9]*$')):
+    """Check whether a string is a valid Python identifier
 
+    Examples
+    --------
     >>> isvalid_identifier('Hello')
     True
     >>> isvalid_identifier('Hello world')
     False
     >>> isvalid_identifier('Helloworld!')
     False
+    >>> isvalid_identifier('1a')
+    False
+    >>> isvalid_identifier('a1')
+    True
+    >>> isvalid_identifier('for')
+    False
     """
-    return not not re.match('^\w+$', s)
+    return not keyword.iskeyword(s) and regex.match(s) is not None
 
 
 def valid_identifier(s):
-    """
-
+    """Rewrite a string to be a valid identifier if it contains
     >>> valid_identifier('hello')
     'hello'
     >>> valid_identifier('hello world')
@@ -48,10 +57,12 @@ def valid_identifier(s):
     'hello_world'
     >>> valid_identifier('hello-world')
     'hello_world'
-    >>> print(valid_identifier(None))
-    None
+    >>> valid_identifier(None)
+    >>> valid_identifier('1a')
     """
     if isinstance(s, _strtypes):
+        if s[0].isdigit():
+            return
         return s.replace(' ', '_').replace('.', '_').replace('-', '_')
     return s
 

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -489,20 +489,21 @@ class ReLabel(ElemWise):
     @property
     def schema(self):
         subs = dict(self.labels)
-        d = self._child.dshape.measure.dict
-
+        param = self._child.dshape.measure.parameters[0]
         return DataShape(Record([[subs.get(name, name), dtype]
-            for name, dtype in self._child.dshape.measure.parameters[0]]))
+                                 for name, dtype in param]))
 
     def __str__(self):
-        return '%s.relabel(%s)' % (self._child, ', '.join('%s="%s"' % l for l
-            in self.labels))
+        return ('%s.relabel(%s)' %
+                (self._child, ', '.join('%s=%r' % l for l in self.labels)))
 
 
 def relabel(child, labels=None, **kwargs):
     labels = labels or dict()
     labels = toolz.merge(labels, kwargs)
     labels = dict((k, v) for k, v in labels.items() if k != v)
+    if not set(labels).issubset(child.fields):
+        raise ValueError("Cannot relabel non-existent child fields")
     if not labels:
         return child
     if isinstance(labels, dict):  # Turn dict into tuples

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -472,16 +472,18 @@ class ReLabel(ElemWise):
 
     Examples
     --------
-
     >>> accounts = symbol('accounts', 'var * {name: string, amount: int}')
     >>> accounts.schema
     dshape("{name: string, amount: int32}")
     >>> accounts.relabel(amount='balance').schema
     dshape("{name: string, balance: int32}")
+    >>> accounts.relabel(not_a_column='definitely_not_a_column')
+    Traceback (most recent call last):
+        ...
+    ValueError: Cannot relabel non-existent child fields
 
     See Also
     --------
-
     blaze.expr.expressions.Label
     """
     __slots__ = '_hash', '_child', 'labels'

--- a/blaze/expr/tests/test_expr.py
+++ b/blaze/expr/tests/test_expr.py
@@ -5,6 +5,7 @@ from blaze.expr import *
 from blaze.expr.core import subs
 from blaze.utils import raises
 
+
 def test_Symbol():
     e = symbol('e', '3 * 5 * {name: string, amount: int}')
     assert e.dshape == dshape('3 * 5 * {name: string, amount: int}')
@@ -98,4 +99,11 @@ def test_symbol_subs():
     e = symbol('e', '{x: int, y: int}')
     f = symbol('f', '{x: int, y: int}')
     d = {'e': 'f'}
-    assert e._subs({'e': 'f'}) is f
+    assert e._subs(d) is f
+
+
+def test_multiple_renames_on_series_fails():
+    t = symbol('s', discover(tframe))
+    ts = t.timestamp
+    with pytest.raises(ValueError):
+        ts.relabel({'timestamp': 'date', 'hello': 'world'})

--- a/blaze/expr/tests/test_expr.py
+++ b/blaze/expr/tests/test_expr.py
@@ -103,7 +103,14 @@ def test_symbol_subs():
 
 
 def test_multiple_renames_on_series_fails():
-    t = symbol('s', discover(tframe))
+    t = symbol('s', 'var * {timestamp: datetime}')
     ts = t.timestamp
-    with pytest.raises(ValueError):
-        ts.relabel({'timestamp': 'date', 'hello': 'world'})
+    assert raises(ValueError, lambda: ts.relabel({'timestamp': 'date',
+                                                  'hello': 'world'}))
+
+
+def test_map_with_rename():
+    t = symbol('s', 'var * {timestamp: datetime}')
+    result = t.timestamp.map(lambda x: x.date(), schema='{date: datetime}')
+    assert raises(ValueError, lambda: result.relabel({'timestamp': 'date'}))
+    assert result.fields == ['date']


### PR DESCRIPTION
* `bcolz` backend now gets its `chunksize` argument from the value passed in or it computes it by taking the minimum `chunklen` of all the columns. the latter method is how `bcolz` itself does it
* `test_pandas_compute.py` now uses either `test_series_equal` or `test_frame_equal` for testing, rather than `assert str(df) == str(df2)`. this exposed a few minor issues that i fixed.
* more doctests
* tests now pass that were failing (in `test_pandas_compute.py`)
* relabeling fields that don't exist raises an error
* map with rename test was redundant, now it's not
* remove unused bcolz chunks function and single associated test,
  this is now in the [`into`](https://github.com/ContinuumIO/into) project
* robustify valid identifier checking
* compute_up(symbol, DataFrame) was removed because it was never executed:
  compute will look for expressions in scope before dispatching on compute_up
  and will subsequently return the frame (because that symbol is in scope)