### PR TITLE
sql: post_compute yields select, not iterator

### DIFF
--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -553,38 +553,6 @@ def engine_of(x):
     raise NotImplementedError("Can't deterimine engine of %s" % x)
 
 
-@dispatch(Expr, sqlalchemy.sql.ClauseElement)
-def post_compute(expr, query, scope=None):
-    """ Execute SQLAlchemy query against SQLAlchemy engines
-
-    If the result of compute is a SQLAlchemy query then it is likely that the
-    data elements are themselves SQL objects which contain SQLAlchemy engines.
-    We find these engines and, if they are all the same, run the query against
-    these engines and return the result.
-    """
-    if not all(isinstance(val, (Engine, MetaData, Table)) for val in scope.values()):
-        return query
-
-    engines = set(filter(None, map(engine_of, scope.values())))
-
-    if not engines:
-        return query
-
-    if len(set(map(str, engines))) != 1:
-        raise NotImplementedError("Expected single SQLAlchemy engine")
-
-    engine = toolz.first(engines)
-
-    with engine.connect() as conn:  # Perform query
-        result = conn.execute(select(query)).fetchall()
-
-    if isscalar(expr.dshape):
-        return result[0][0]
-    if isscalar(expr.dshape.measure):
-        return [x[0] for x in result]
-    return result
-
-
 from ..expr.broadcast import broadcast_collect
 
 
@@ -596,3 +564,8 @@ def optimize(expr, _):
 @dispatch(Field, sqlalchemy.MetaData)
 def compute_up(expr, data, **kwargs):
     return table_of_metadata(data, expr._name)
+
+
+@dispatch(Expr, sa.sql.elements.ClauseElement)
+def post_compute(_, s, **kwargs):
+    return select(s)

--- a/blaze/tests/test_sql.py
+++ b/blaze/tests/test_sql.py
@@ -29,11 +29,11 @@ def sql():
 def test_column(sql):
     t = Data(sql)
 
-    r = compute(t['x'])
+    r = list(t['x'])
     assert r == [1, 10, 100]
-    assert compute(t[['x']]) == [(1,), (10,), (100,)]
+    assert list(t[['x']]) == [(1,), (10,), (100,)]
 
-    assert compute(t.count()) == 3
+    assert int(t.count()) == 3
 
 
 def test_drop(sql):


### PR DESCRIPTION
Compute calls on SQL tables no longer immediately become iterators
Instead they stay Select objects

    In [1]: from blaze import *

    In [2]: iris = Data('sqlite:///workspace/blaze/blaze/examples/data/iris.db::iris')

    In [3]: compute(iris[iris.species == 'Iris-setosa'])
    Out[3]: <sqlalchemy.sql.selectable.Select at 0x7f2d8abb4f10; Select object>

This depends on https://github.com/ContinuumIO/into/pull/40 and will be particularly useful after https://github.com/ContinuumIO/into/pull/37