### PR TITLE
BUG: InteractiveSymbol repr fails on dict_slice (WIP)

### DIFF
--- a/blaze/interactive.py
+++ b/blaze/interactive.py
@@ -237,7 +237,7 @@ def expr_repr(expr, n=10):
     # Other
     dat = expr._resources().values()
     if len(dat) == 1:
-        dat = dat[0]
+        dat = list(dat)[0]  # may be dict_values
 
     s = 'Data:       %s' % dat
     if not isinstance(expr, Symbol):


### PR DESCRIPTION
One py3 error I ran into was trying to slice a `dict_values` object in the expr_repr of a redshift database. Maybe hold off on merging this for now because it looks like computations are still failing on the Data object (but working fine for python 2).

If I try a computation like `rs.table.head()`, where `rs` was created by passing in a SQLAlchemy engine to `Data`, I get a NotImplementedError.

```
expr: _2.table.head(10).head(11)
data: _2: Engine(<my redshift engine>)
```

It's a bit tricky to debug since my work computer is remote and locked down, but I'll see what I can do.