### PR TITLE
Iterator is no longer in into

### DIFF
--- a/blaze/compute/json.py
+++ b/blaze/compute/json.py
@@ -1,8 +1,9 @@
 from .core import pre_compute
 from ..dispatch import dispatch
-from ..expr import Expr, Head, ElemWise, Distinct, Symbol, Projection, Field
+from ..expr import Expr
 from into.backends.json import JSON, JSONLines
-from into import into, Iterator
+from into import into
+from collections import Iterator
 from into.utils import records_to_tuples
 
 


### PR DESCRIPTION
in anticipation of aws work

we also shouldn't make other projects that depend on into depend on the stdlib
imports that it yields, rather we should import from the stdlib