### PR TITLE
Fix SQL repring bug

### DIFF
--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -457,9 +457,16 @@ def compute_up(t, s, **kwargs):
     return s.order_by(col)
 
 
-@dispatch(Head, (Select, ClauseElement))
+@dispatch(Head, Select)
 def compute_up(t, s, **kwargs):
-    return select([s]).limit(t.n)
+    if s._limit is not None and s._limit < t.n:
+        return s
+    return s.limit(t.n)
+
+
+@dispatch(Head, ClauseElement)
+def compute_up(t, s, **kwargs):
+    return select(s).limit(t.n)
 
 
 @dispatch(Label, ClauseElement)

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -459,7 +459,7 @@ def compute_up(t, s, **kwargs):
 
 @dispatch(Head, Select)
 def compute_up(t, s, **kwargs):
-    if s._limit is not None and s._limit < t.n:
+    if s._limit is not None and s._limit <= t.n:
         return s
     return s.limit(t.n)
 

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -457,14 +457,9 @@ def compute_up(t, s, **kwargs):
     return s.order_by(col)
 
 
-@dispatch(Head, Select)
+@dispatch(Head, (Select, ClauseElement))
 def compute_up(t, s, **kwargs):
-    return s.limit(t.n)
-
-
-@dispatch(Head, ClauseElement)
-def compute_up(t, s, **kwargs):
-    return select(s).limit(t.n)
+    return select([s]).limit(t.n)
 
 
 @dispatch(Label, ClauseElement)

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -5,14 +5,13 @@ sqlalchemy = pytest.importorskip('sqlalchemy')
 sa = sqlalchemy
 
 import re
-from itertools import repeat
 
-import pandas as pd
 import pandas.util.testing as tm
 
 import datashape
 
-from blaze.compute.sql import compute, computefull, select, lower_column
+from blaze.compute.sql import (compute, computefull, select, lower_column,
+                               compute_up)
 from blaze.expr import *
 from blaze import Data
 from blaze.compatibility import xfail
@@ -1090,6 +1089,6 @@ def test_head_compute():
     # skip the header and the ... at the end of the repr
     expr = d.head(n)
     s = repr(expr)
-    split = s.split('\n')
-    result = (split if split[-1] != '...' else split[:-1])[1:]
+    assert '...' not in s
+    result = s.split('\n')[1:]
     assert len(result) == n

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -6,14 +6,11 @@ sa = sqlalchemy
 
 import re
 
-import pandas.util.testing as tm
-
 import datashape
 
 from blaze.compute.sql import (compute, computefull, select, lower_column,
                                compute_up)
 from blaze.expr import *
-from blaze import Data
 from blaze.compatibility import xfail
 from blaze.utils import unique
 from pandas import DataFrame
@@ -1079,16 +1076,7 @@ def test_merge_compute():
                           (4, 'Dennis',400, 4000)]
 
 
-def test_head_compute():
-    data = tm.makeMixedDataFrame()
-    t = symbol('t', discover(data))
-    db = into('sqlite:///:memory:::t', data, dshape=t.dshape)
-    n = 2
-    d = Data(db)
-
-    # skip the header and the ... at the end of the repr
-    expr = d.head(n)
-    s = repr(expr)
-    assert '...' not in s
-    result = s.split('\n')[1:]
-    assert len(result) == n
+def test_head_limit():
+    assert compute(t.head(5).head(10))._limit == 5
+    assert compute(t.head(10).head(5))._limit == 5
+    assert compute(t.head(10).head(10))._limit == 5

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -1077,6 +1077,6 @@ def test_merge_compute():
 
 
 def test_head_limit():
-    assert compute(t.head(5).head(10))._limit == 5
-    assert compute(t.head(10).head(5))._limit == 5
-    assert compute(t.head(10).head(10))._limit == 5
+    assert compute(t.head(5).head(10), s)._limit == 5
+    assert compute(t.head(10).head(5), s)._limit == 5
+    assert compute(t.head(10).head(10), s)._limit == 10

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -2,6 +2,7 @@ from blaze.interactive import Data, compute, concrete_head, expr_repr, to_html
 
 from into import into, append
 from into.backends.csv import CSV
+from blaze import discover
 from blaze.compute.core import compute
 from blaze.compute.python import compute
 from blaze.expr import symbol
@@ -308,3 +309,18 @@ def test_DataFrame():
     x = np.array([(1, 2), (1., 2.)], dtype=[('a', 'i4'), ('b', 'f4')])
     d = Data(x)
     assert isinstance(pd.DataFrame(d), pd.DataFrame)
+
+
+def test_head_compute():
+    data = tm.makeMixedDataFrame()
+    t = symbol('t', discover(data))
+    db = into('sqlite:///:memory:::t', data, dshape=t.dshape)
+    n = 2
+    d = Data(db)
+
+    # skip the header and the ... at the end of the repr
+    expr = d.head(n)
+    s = repr(expr)
+    assert '...' not in s
+    result = s.split('\n')[1:]
+    assert len(result) == n


### PR DESCRIPTION
fixes an issue with repring of the sql engine, where calling `t.head(2).head(3)` would take the most recent call rather than the minimum
