### PR TITLE
Add vector norm

### DIFF
--- a/blaze/compute/mongo.py
+++ b/blaze/compute/mongo.py
@@ -63,6 +63,7 @@ from ..expr import (var, Label, std, Sort, count, nunique, nelements, Selection,
                     Eq, Ne, And, Or, Summary, Like, Broadcast, DateTime,
                     Microsecond, Date, Time, Expr, symbol, Arithmetic, floor,
                     ceil, FloorDiv)
+from ..expr import math
 from ..expr.datetime import Day, Month, Year, Minute, Second, UTCFromTimestamp
 from ..compatibility import _strtypes
 from .core import compute
@@ -181,6 +182,11 @@ def compute_sub(t):
     elif isinstance(t, floor):
         x = compute_sub(t._child)
         return {'$subtract': [x, {'$mod': [x, 1]}]}
+    elif isinstance(t, math.abs):
+        x = compute_sub(t._child)
+        return {'$cond': [{'$lt': [x, 0]},
+                          {'$subtract': [0, x]},
+                          x]}
     elif isinstance(t, ceil):
         x = compute_sub(t._child)
         return {'$add': [x,

--- a/blaze/compute/pyfunc.py
+++ b/blaze/compute/pyfunc.py
@@ -4,6 +4,7 @@ from ..expr import (Expr, Symbol, Field, Arithmetic, Math,
                     Date, Time, DateTime, Millisecond, Microsecond, broadcast,
                     sin, cos, Map, UTCFromTimestamp, DateTimeTruncate, symbol,
                     USub, Not)
+from ..expr import math as expr_math
 from ..expr.expressions import valid_identifier
 from ..dispatch import dispatch
 from . import pydatetime
@@ -102,6 +103,10 @@ def _print_python(expr, leaves=None):
     return ('math.%s(%s)' % (type(expr).__name__, child),
             toolz.merge(scope, {'math': math}))
 
+@dispatch(expr_math.abs)
+def _print_python(expr, leaves=None):
+    child, scope = print_python(leaves, expr._child)
+    return ('abs(%s)' % child, scope)
 
 @dispatch(Date)
 def _print_python(expr, leaves=None):

--- a/blaze/compute/tests/test_comprehensive.py
+++ b/blaze/compute/tests/test_comprehensive.py
@@ -15,11 +15,11 @@ sources = []
 
 t = symbol('t', 'var * {amount: int64, id: int64, name: string}')
 
-L = [[100, 1, 'Alice'],
-     [200, 2, 'Bob'],
-     [300, 3, 'Charlie'],
-     [400, 4, 'Dan'],
-     [500, 5, 'Edith']]
+L = [[ 100, 1, 'Alice'],
+     [ 200, 2, 'Bob'],
+     [ 300, 3, 'Charlie'],
+     [-400, 4, 'Dan'],
+     [ 500, 5, 'Edith']]
 
 df = DataFrame(L, columns=['amount', 'id', 'name'])
 
@@ -61,6 +61,7 @@ if pymongo:
 expressions = {
         t: [],
         t['id']: [],
+        abs(t['amount']): [],
         t.id.max(): [],
         t.amount.sum(): [],
         t.amount.sum(keepdims=True): [],

--- a/blaze/compute/tests/test_numpy_compute.py
+++ b/blaze/compute/tests/test_numpy_compute.py
@@ -392,7 +392,8 @@ def test_vector_norm():
               np.linalg.norm(x))
     assert eq(compute(s.vnorm(ord=1), x),
               np.linalg.norm(x.flatten(), ord=1))
-    assert eq(compute(s.vnorm(ord=1, axis=0), x),
-              np.linalg.norm(x, ord=1, axis=0))
-    assert eq(compute(s.vnorm(ord=4, axis=0, keepdims=True), x),
-              np.linalg.norm(x, ord=4, axis=0, keepdims=True))
+    assert eq(compute(s.vnorm(ord=4, axis=0), x),
+              np.linalg.norm(x, ord=4, axis=0))
+
+    expr = s.vnorm(ord=4, axis=0, keepdims=True)
+    assert expr.shape == compute(expr, x).shape

--- a/blaze/compute/tests/test_numpy_compute.py
+++ b/blaze/compute/tests/test_numpy_compute.py
@@ -382,3 +382,17 @@ def test_map():
     assert type(result) == type(expected)
 
     np.testing.assert_array_equal(result, expected)
+
+
+def test_vector_norm():
+    x = np.arange(30).reshape((5, 6))
+    s = symbol('x', discover(x))
+
+    assert eq(compute(s.vnorm(), x),
+              np.linalg.norm(x))
+    assert eq(compute(s.vnorm(ord=1), x),
+              np.linalg.norm(x.flatten(), ord=1))
+    assert eq(compute(s.vnorm(ord=1, axis=0), x),
+              np.linalg.norm(x, ord=1, axis=0))
+    assert eq(compute(s.vnorm(ord=1, axis=0, keepdims=True), x),
+              np.linalg.norm(x, ord=1, axis=0, keepdims=True))

--- a/blaze/compute/tests/test_numpy_compute.py
+++ b/blaze/compute/tests/test_numpy_compute.py
@@ -394,5 +394,5 @@ def test_vector_norm():
               np.linalg.norm(x.flatten(), ord=1))
     assert eq(compute(s.vnorm(ord=1, axis=0), x),
               np.linalg.norm(x, ord=1, axis=0))
-    assert eq(compute(s.vnorm(ord=1, axis=0, keepdims=True), x),
-              np.linalg.norm(x, ord=1, axis=0, keepdims=True))
+    assert eq(compute(s.vnorm(ord=4, axis=0, keepdims=True), x),
+              np.linalg.norm(x, ord=4, axis=0, keepdims=True))

--- a/blaze/compute/tests/test_numpy_compute.py
+++ b/blaze/compute/tests/test_numpy_compute.py
@@ -57,6 +57,9 @@ def test_UnaryOp():
     assert eq(compute(exp(t['amount']), x),
               np.exp(x['amount']))
 
+    assert eq(compute(abs(-t['amount']), x),
+              abs(-x['amount']))
+
 
 def test_Neg():
     assert eq(compute(-t['amount'], x),

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -123,6 +123,8 @@ def test_multi_column_join():
 def test_unary_op():
     assert (compute(exp(t['amount']), df) == np.exp(df['amount'])).all()
 
+def test_abs():
+    assert (compute(abs(t['amount']), df) == abs(df['amount'])).all()
 
 def test_neg():
     tm.assert_series_equal(compute(-t['amount'], df),

--- a/blaze/compute/tests/test_pyfunc.py
+++ b/blaze/compute/tests/test_pyfunc.py
@@ -29,8 +29,8 @@ def test_map():
 
 
 def test_math():
-    f = lambdify([t], t.x + cos(t.y))
-    assert f((1, 0, 3, 4)) == 1 + math.cos(0.0)
+    f = lambdify([t], abs(t.x) + cos(t.y))
+    assert f((-1, 0, 3, 4)) == 1 + math.cos(0.0)
 
 
 def test_datetime_literals_and__print_python():

--- a/blaze/expr/arithmetic.py
+++ b/blaze/expr/arithmetic.py
@@ -204,6 +204,11 @@ def scalar_coerce(ds, val):
         return None
 
 
+@dispatch((ct.Mono, ct.Option, DataShape), Expr)
+def scalar_coerce(ds, val):
+    return val
+
+
 @dispatch(ct.Date, _strtypes)
 def scalar_coerce(_, val):
     dt = dt_parse(val)

--- a/blaze/expr/arithmetic.py
+++ b/blaze/expr/arithmetic.py
@@ -204,7 +204,7 @@ def scalar_coerce(ds, val):
         return None
 
 
-@dispatch((ct.Mono, ct.Option, DataShape), Expr)
+@dispatch((ct.Record, ct.Mono, ct.Option, DataShape), Expr)
 def scalar_coerce(ds, val):
     return val
 

--- a/blaze/expr/core.py
+++ b/blaze/expr/core.py
@@ -216,6 +216,10 @@ class Node(object):
     def __invert__(self):
         return self._invert()
 
+    def __abs__(self):
+        from .math import abs
+        return abs(self)
+
 
 def isidentical(a, b):
     """ Strict equality testing

--- a/blaze/expr/math.py
+++ b/blaze/expr/math.py
@@ -21,6 +21,7 @@ class RealMath(Math):
     _dtype = real
 
 
+class abs(RealMath): pass
 class sqrt(RealMath): pass
 
 class sin(RealMath): pass

--- a/blaze/expr/reductions.py
+++ b/blaze/expr/reductions.py
@@ -275,7 +275,7 @@ def summary(keepdims=False, axis=None, **kwargs):
 summary.__doc__ = Summary.__doc__
 
 
-def norm(expr, ord=None, axis=None, keepdims=None):
+def vnorm(expr, ord=None, axis=None, keepdims=False):
     """ Vector norm
 
     See np.linalg.norm
@@ -287,7 +287,7 @@ def norm(expr, ord=None, axis=None, keepdims=None):
     elif ord == -inf:
         return min(abs(expr), axis=axis, keepdims=keepdims)
     else:
-        return sum((abs(expr)**ord)**(1./ord), axis=axis, keepdims=keepdims)
+        return sum(abs(expr)**ord, axis=axis, keepdims=keepdims)**(1./ord)
 
 
 from datashape.predicates import iscollection, isboolean, isnumeric
@@ -300,7 +300,7 @@ dshape_method_list.extend([
     (lambda ds: iscollection(ds) and isboolean(ds),
         set([any, all, sum])),
     (lambda ds: iscollection(ds) and isnumeric(ds),
-        set([mean, sum, mean, min, max, std, var, norm])),
+        set([mean, sum, mean, min, max, std, var, vnorm])),
     ])
 
 method_properties.update([nrows])

--- a/blaze/expr/reductions.py
+++ b/blaze/expr/reductions.py
@@ -4,6 +4,7 @@ import toolz
 from datashape import Record, DataShape, dshape
 from datashape import coretypes as ct
 import datashape
+from numpy import inf
 
 from .core import common_subexpression
 from .expressions import Expr, symbol, ndim, Slice
@@ -274,6 +275,21 @@ def summary(keepdims=False, axis=None, **kwargs):
 summary.__doc__ = Summary.__doc__
 
 
+def norm(expr, ord=None, axis=None, keepdims=None):
+    """ Vector norm
+
+    See np.linalg.norm
+    """
+    if ord is None or ord == 'fro':
+        ord = 2
+    if ord == inf:
+        return max(abs(expr), axis=axis, keepdims=keepdims)
+    elif ord == -inf:
+        return min(abs(expr), axis=axis, keepdims=keepdims)
+    else:
+        return sum((abs(expr)**ord)**(1./ord), axis=axis, keepdims=keepdims)
+
+
 from datashape.predicates import iscollection, isboolean, isnumeric
 from .expressions import dshape_method_list, method_properties
 
@@ -284,7 +300,7 @@ dshape_method_list.extend([
     (lambda ds: iscollection(ds) and isboolean(ds),
         set([any, all, sum])),
     (lambda ds: iscollection(ds) and isnumeric(ds),
-        set([mean, sum, mean, min, max, std, var])),
+        set([mean, sum, mean, min, max, std, var, norm])),
     ])
 
 method_properties.update([nrows])

--- a/blaze/expr/reductions.py
+++ b/blaze/expr/reductions.py
@@ -286,6 +286,8 @@ def vnorm(expr, ord=None, axis=None, keepdims=False):
         return max(abs(expr), axis=axis, keepdims=keepdims)
     elif ord == -inf:
         return min(abs(expr), axis=axis, keepdims=keepdims)
+    elif ord == 1:
+        return sum(abs(expr), axis=axis, keepdims=keepdims)
     else:
         return sum(abs(expr)**ord, axis=axis, keepdims=keepdims)**(1./ord)
 

--- a/blaze/expr/reductions.py
+++ b/blaze/expr/reductions.py
@@ -288,6 +288,8 @@ def vnorm(expr, ord=None, axis=None, keepdims=False):
         return min(abs(expr), axis=axis, keepdims=keepdims)
     elif ord == 1:
         return sum(abs(expr), axis=axis, keepdims=keepdims)
+    elif ord % 2 == 0:
+        return sum(expr**ord, axis=axis, keepdims=keepdims)**(1./ord)
     else:
         return sum(abs(expr)**ord, axis=axis, keepdims=keepdims)**(1./ord)
 

--- a/blaze/expr/tests/test_functions.py
+++ b/blaze/expr/tests/test_functions.py
@@ -1,14 +1,15 @@
 from __future__ import absolute_import, division, print_function
 
 from blaze.expr.functions import *
-from blaze.expr import TableSymbol, Expr, Symbol
+from blaze.expr import Expr, symbol
+from blaze.expr import math
 import numpy as np
 
 
 def test_reductions():
     assert max([1, 2, 3]) == 3
     assert max(np.array([1, 2, 3])) == 3
-    assert isinstance(max(TableSymbol('t', '{x: int, y: int}').x), Expr)
+    assert isinstance(max(symbol('t', 'var * {x: int, y: int}').x), Expr)
     assert all([True, True, True]) is True
     assert all([True, True, False]) is False
 
@@ -17,4 +18,11 @@ def test_math():
     assert sin(0) == 0
     assert isinstance(sin(0), float)
     assert isinstance(sin(np.int32(0)), np.float)
-    assert isinstance(sin(Symbol('x', 'real')), Expr)
+    assert isinstance(sin(symbol('x', 'real')), Expr)
+
+
+def test_abs():
+    assert abs(-1) == 1
+    assert (abs(np.array([-1, 2, 3])) == np.array([1, 2, 3])).all()
+    x = symbol('x', 'int')
+    assert isinstance(abs(x), math.abs)

--- a/blaze/expr/tests/test_math.py
+++ b/blaze/expr/tests/test_math.py
@@ -1,7 +1,11 @@
 from blaze.expr import *
 from blaze.expr.math import *
+from blaze.expr.math import abs as mathabs
 
 x = symbol('x', '5 * 3 * int')
 
 def test_math_shapes():
     assert sin(x).shape == x.shape
+
+def test_abs():
+    assert abs(x).isidentical(mathabs(x))

--- a/blaze/expr/tests/test_reductions.py
+++ b/blaze/expr/tests/test_reductions.py
@@ -65,7 +65,7 @@ def test_dir():
 
 def test_norms():
     x = symbol('x', '5 * 3 * float32')
-    assert x.norm().isidentical(x.norm('fro'))
-    assert x.norm().isidentical(x.norm(2))
-    assert x.norm(axis=0).shape == (3,)
-    assert x.norm(axis=0, keepdims=True).shape == (1, 3)
+    assert x.vnorm().isidentical(x.vnorm('fro'))
+    assert x.vnorm().isidentical(x.vnorm(2))
+    assert x.vnorm(axis=0).shape == (3,)
+    assert x.vnorm(axis=0, keepdims=True).shape == (1, 3)

--- a/blaze/expr/tests/test_reductions.py
+++ b/blaze/expr/tests/test_reductions.py
@@ -61,3 +61,11 @@ def test_dir():
 
     t = symbol('t', 'int')
     assert 'mean' not in dir(t)
+
+
+def test_norms():
+    x = symbol('x', '5 * 3 * float32')
+    assert x.norm().isidentical(x.norm('fro'))
+    assert x.norm().isidentical(x.norm(2))
+    assert x.norm(axis=0).shape == (3,)
+    assert x.norm(axis=0, keepdims=True).shape == (1, 3)

--- a/blaze/expr/tests/test_scalar.py
+++ b/blaze/expr/tests/test_scalar.py
@@ -258,6 +258,8 @@ def test_scalar_coerce():
     assert scalar_coerce('?date', '') == None
     assert scalar_coerce('?int', 0) == 0
     assert scalar_coerce('?int', '0') == 0
+    x = symbol('x', '?int')
+    assert scalar_coerce('?int', x) is x
 
 
 def test_scalar_name_dtype():

--- a/blaze/tests/test_core.py
+++ b/blaze/tests/test_core.py
@@ -1,8 +1,10 @@
 from blaze import into, drop, create_index
 from blaze.compute.core import compute_down, compute_up
 from multipledispatch.conflict import ambiguities
+from blaze.expr.arithmetic import scalar_coerce
 
 
 def test_no_dispatch_ambiguities():
-    for func in [into, compute_up, compute_down, drop, create_index]:
+    for func in [into, compute_up, compute_down, drop, create_index,
+                 scalar_coerce]:
         assert not ambiguities(func.funcs)


### PR DESCRIPTION
Add a vector norm function on to `Expr` if the dshape is array-like.

This closely follows `np.linalg.norm` although it only performs vector norms not possibly matrix norms (hence the prepended `v` to the name.)  If you don't know what the difference is then you probably wanted vector norms anyway.  This is only a function not an expression.  It defines itself in terms of other expressions so it should fit in nicely to other systems, like blocking algorithms, as is.

```Python
In [1]: from blaze import Data, np, into, compute

In [2]: x = Data(np.arange(30).reshape((5, 6)))

In [3]: x.vnorm()
Out[3]: 92.493242996448117

In [4]: x.vnorm(ord=1)
Out[4]: 435.0

In [5]: x.vnorm(ord=3, axis=1, keepdims=True)
Out[5]: 
array([[  6.082202  ],
       [ 16.04544372],
       [ 26.70880491],
       [ 37.50773174],
       [ 48.35286831]])
```

I also had to implement `abs`

```Python
In [6]: abs(-x)
Out[6]: 
array([[  0.,   1.,   2.,   3.,   4.,   5.],
       [  6.,   7.,   8.,   9.,  10.,  11.],
       [ 12.,  13.,  14.,  15.,  16.,  17.],
       [ 18.,  19.,  20.,  21.,  22.,  23.],
       [ 24.,  25.,  26.,  27.,  28.,  29.]])
```