### PR TITLE
Is in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ blaze.egg-info
 
 
 __conda_version__.txt
+
+# Vagrant related ignores
+Vagrantfile
+.vagrant/*

--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -430,7 +430,7 @@ class IsIn(Map):
 
     Parameters
     ----------
-    seq : tuple
+    seq : iterable
 
     """
 

--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -6,10 +6,10 @@ from datashape import Option, Record, Unit, dshape, var
 from datashape.predicates import isscalar, iscollection, isrecord
 
 from .core import common_subexpression
-from .expressions import Expr, ElemWise, label
+from .expressions import Expr, ElemWise, label, Map
 
 __all__ = ['Sort', 'Distinct', 'Head', 'Merge', 'distinct', 'merge',
-           'head', 'sort', 'Join', 'join', 'transform']
+           'head', 'sort', 'Join', 'join', 'transform', 'isin']
 
 class Sort(Expr):
     """ Table in sorted order
@@ -425,9 +425,18 @@ def join(lhs, rhs, on_left=None, on_right=None, how='inner'):
 join.__doc__ = Join.__doc__
 
 
+def isin(t, seq):
+    """ Checks if every element is in another sequence
+    :param seq: the sequence to check against
+    :return: a 1d sequence of boolean
+    """
+    def f(elem):
+        return elem in set(seq)
+    return Map(t, f, datashape.bool_, 'isin')
+
 from .expressions import dshape_method_list
 
 dshape_method_list.extend([
-    (iscollection, set([sort, head])),
+    (iscollection, set([sort, head, isin])),
     (lambda ds: len(ds.shape) == 1, set([distinct])),
     ])

--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -8,7 +8,7 @@ from datashape.predicates import isscalar, iscollection, isrecord
 from .core import common_subexpression
 from .expressions import Expr, ElemWise, label, Map
 
-__all__ = ['Sort', 'Distinct', 'Head', 'Merge', 'distinct', 'merge',
+__all__ = ['Sort', 'Distinct', 'Head', 'Merge', 'IsIn', 'distinct', 'merge',
            'head', 'sort', 'Join', 'join', 'transform', 'isin']
 
 class Sort(Expr):
@@ -431,6 +431,7 @@ class IsIn(Map):
 
     @property
     def func(self):
+        # do this to gracefully degrade to map in case no special IsIn operation
         def inner(element):
             return element in self.seq
         return inner

--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -426,6 +426,14 @@ join.__doc__ = Join.__doc__
 
 
 class IsIn(Map):
+    """Tests if every element is a member of a set
+
+    Parameters
+    ----------
+    seq : tuple
+
+    """
+
     __slots__ = '_hash', '_child', 'seq'
 
 
@@ -451,6 +459,9 @@ def isin(t, seq):
     :return: a 1d sequence of boolean
     """
     return IsIn(t, tuple(set(seq)))
+
+isin.__doc__ = IsIn.__doc__
+
 
 from .expressions import dshape_method_list
 

--- a/blaze/expr/collections.py
+++ b/blaze/expr/collections.py
@@ -425,14 +425,31 @@ def join(lhs, rhs, on_left=None, on_right=None, how='inner'):
 join.__doc__ = Join.__doc__
 
 
+class IsIn(Map):
+    __slots__ = '_hash', '_child', 'seq'
+
+
+    @property
+    def func(self):
+        def inner(element):
+            return element in self.seq
+        return inner
+
+    @property
+    def schema(self):
+        return datashape.bool_
+
+    @property
+    def _name(self):
+        return "isin"
+
+
 def isin(t, seq):
     """ Checks if every element is in another sequence
     :param seq: the sequence to check against
     :return: a 1d sequence of boolean
     """
-    def f(elem):
-        return elem in set(seq)
-    return Map(t, f, datashape.bool_, 'isin')
+    return IsIn(t, tuple(set(seq)))
 
 from .expressions import dshape_method_list
 

--- a/blaze/expr/tests/test_collections.py
+++ b/blaze/expr/tests/test_collections.py
@@ -67,3 +67,8 @@ def test_raise_error_if_join_on_no_columns():
     b = symbol('b', 'var * {y: int}')
 
     assert raises(ValueError, lambda: join(a, b))
+
+
+def test_isin():
+    assert hasattr('isin', t.x)
+    # not sure how to test abstractly, it just piggybacks map

--- a/blaze/expr/tests/test_collections.py
+++ b/blaze/expr/tests/test_collections.py
@@ -70,5 +70,5 @@ def test_raise_error_if_join_on_no_columns():
 
 
 def test_isin():
-    assert hasattr('isin', t.x)
+    assert hasattr(t.x, 'isin')
     # not sure how to test abstractly, it just piggybacks map


### PR DESCRIPTION
Although I can't think of any usages outside of a selection, subclassing from expressions.Map seems to give a more general solution. 

That being said, it is only used as a selector in sqlalchemy (presumably mongo as well) and I'm not sure if this breaks any future compatibility with those libraries. 

Not sure how to test given it just piggybacks on Map. 