### PR TITLE
Support slicing with lists/arrays of ints/booleans

### DIFF
--- a/blaze/expr/tests/test_slicing.py
+++ b/blaze/expr/tests/test_slicing.py
@@ -1,4 +1,5 @@
 from blaze.expr import symbol
+import numpy as np
 from datashape import dshape, isscalar
 
 
@@ -55,3 +56,14 @@ def test_list_slice():
 def test_list_slice_string():
     x = symbol('x', '10 * 10 * int32')
     assert str(x[[1, 2, 3]]) == "x[[1, 2, 3]]"
+
+
+def test_slice_with_boolean_list():
+    x = symbol('x', '5 * int32')
+    expr = x[[True, False, False, True, False]]
+    assert expr.index == ([0, 3],)
+
+
+def test_slice_with_numpy_array():
+    x = symbol('x', '2 * int32')
+    assert x[np.array([True, False])].isidentical(x[[True, False]])

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -235,7 +235,7 @@ def from_tree(expr, namespace=None):
     if isinstance(expr, dict):
         op, args = expr['op'], expr['args']
         if 'slice' == op:
-            return slice(*[from_tree(arg, namespace) for arg in args])
+            return expr_utils._slice(*[from_tree(arg, namespace) for arg in args])
         if hasattr(blaze.expr, op):
             cls = getattr(blaze.expr, op)
         else:


### PR DESCRIPTION
These all get translated into tuples of ints.

```python
In [1]: from blaze import Data, np, into, compute

In [2]: import dask.array as da

In [3]: x = Data(into(da.Array, np.arange(5), blockshape=(2,)))

In [4]: np.array(x[[True, False, False, False, True]])
Out[4]: array([0, 4])

In [5]: np.array(x[np.array([True, False, False, False, True])])
Out[5]: array([0, 4])
```

This should compose fine with recent work on fancy indexing.

cc @shoyer