### PR TITLE
Default pmap

### DIFF
--- a/blaze/__init__.py
+++ b/blaze/__init__.py
@@ -25,6 +25,7 @@ from .expr.arrays import (tensordot, transpose)
 from .expr.functions import *
 from .index import create_index
 from .interactive import *
+from .compute.pmap import set_default_pmap
 from .compute.csv import *
 from .compute.json import *
 from .compute.python import *

--- a/blaze/compute/bcolz.py
+++ b/blaze/compute/bcolz.py
@@ -13,6 +13,7 @@ from ..expr.optimize import lean_projection
 from ..expr.split import split
 from ..partition import partitions
 from .core import compute
+from .pmap import get_default_pmap
 
 from collections import Iterator, Iterable
 import datashape
@@ -101,7 +102,10 @@ def get_chunksize(data):
 
 
 @dispatch(Expr, (bcolz.carray, bcolz.ctable))
-def compute_down(expr, data, chunksize=None, map=map, **kwargs):
+def compute_down(expr, data, chunksize=None, map=None, **kwargs):
+    if map is None:
+        map = get_default_pmap()
+
     leaf = expr._leaves()[0]
 
     if chunksize is None:

--- a/blaze/compute/chunks.py
+++ b/blaze/compute/chunks.py
@@ -12,6 +12,7 @@ import numpy as np
 from ..expr import Head, ElemWise, Distinct, Symbol, Expr, path
 from ..expr.split import split
 from .core import compute
+from .pmap import get_default_pmap
 
 Cheap = (Head, ElemWise, Distinct, Symbol)
 
@@ -29,7 +30,10 @@ def compute_chunk(chunk, chunk_expr, part):
 
 
 @dispatch(Expr, Chunks)
-def compute_down(expr, data, map=map, **kwargs):
+def compute_down(expr, data, map=None, **kwargs):
+    if map is None:
+        map = get_default_pmap()
+
     leaf = expr._leaves()[0]
 
     (chunk, chunk_expr), (agg, agg_expr) = split(leaf, expr)

--- a/blaze/compute/csv.py
+++ b/blaze/compute/csv.py
@@ -18,6 +18,7 @@ from ..utils import available_memory
 from ..expr.split import split
 from .core import compute
 from ..expr.optimize import lean_projection
+from .pmap import get_default_pmap
 
 
 @dispatch(Expr, CSV)
@@ -66,7 +67,9 @@ def compute_chunk(chunk, chunk_expr, part):
 
 
 @dispatch(Expr, pandas.io.parsers.TextFileReader)
-def compute_down(expr, data, map=map, **kwargs):
+def compute_down(expr, data, map=None, **kwargs):
+    if map is None:
+        map = get_default_pmap()
     leaf = expr._leaves()[0]
 
     (chunk, chunk_expr), (agg, agg_expr) = split(leaf, expr)

--- a/blaze/compute/pmap.py
+++ b/blaze/compute/pmap.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import, division, print_function
+
+default_map = [map]
+
+def set_default_pmap(func):
+    default_map[0] = func
+
+
+def get_default_pmap():
+    return default_map[0]

--- a/blaze/compute/tests/test_chunks.py
+++ b/blaze/compute/tests/test_chunks.py
@@ -21,3 +21,18 @@ def test_chunks_compute():
 
 def test_chunks_head():
     assert compute(s.head(2), cL) == (1., 2.)
+
+
+def test_pmap_default():
+    flag = [0]
+
+    def mymap(func, seq):
+        flag[0] = True
+        return map(func, seq)
+
+    from blaze import set_default_pmap
+    set_default_pmap(mymap)
+
+    compute(s + 1, cL)
+
+    assert flag[0] is True

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -47,7 +47,7 @@ def isvalid_identifier(s, regex=re.compile('^[_a-zA-Z][_a-zA-Z0-9]*$')):
     >>> isvalid_identifier(None)
     False
     """
-    return s and not keyword.iskeyword(s) and regex.match(s) is not None
+    return not not s and not keyword.iskeyword(s) and regex.match(s) is not None
 
 
 def valid_identifier(s):

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -44,8 +44,10 @@ def isvalid_identifier(s, regex=re.compile('^[_a-zA-Z][_a-zA-Z0-9]*$')):
     True
     >>> isvalid_identifier('for')
     False
+    >>> isvalid_identifier(None)
+    False
     """
-    return not keyword.iskeyword(s) and regex.match(s) is not None
+    return s and not keyword.iskeyword(s) and regex.match(s) is not None
 
 
 def valid_identifier(s):


### PR DESCRIPTION
This adds a new function allowing users to set a default `pmap` function to be used in chunking computations.

```python
In [1]: import blaze as bz

In [2]: from multiprocessing import Pool

In [3]: p = Pool(4)

In [4]: bz.set_default_pmap(p.map)
```

Fixes #964 