### PR TITLE
Make interactive repr robust to data that doesn't fit in DataFrame

### DIFF
--- a/blaze/interactive.py
+++ b/blaze/interactive.py
@@ -12,6 +12,7 @@ import warnings
 from collections import Iterator
 
 from .expr import Expr, Symbol, ndim
+from .utils import ignoring
 from .dispatch import dispatch
 from into import into, resource
 from .compatibility import _strtypes
@@ -248,8 +249,9 @@ def expr_repr(expr, n=10):
             return repr(compute(expr))
 
     # Tables
-    if ndim(expr) == 1:
-        return repr_tables(expr, 10)
+    with ignoring(Exception):
+        if ndim(expr) == 1:
+            return repr_tables(expr, 10)
 
     # Smallish arrays
     if ndim(expr) >= 2 and numel(expr.shape) and numel(expr.shape) < 1000000:

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -353,3 +353,9 @@ def test_coerce_date_and_datetime():
     x = datetime.datetime.now()
     d = Data(x)
     assert repr(d) == repr(x)
+
+
+def test_highly_nested_repr():
+    data = [[0, [[1, 2], [3]], 'abc']]
+    d = Data(data)
+    assert 'abc' in repr(d.head())


### PR DESCRIPTION
Previously everything with a record datashape was pushed in to a
dataframe.  In some cases this would raise an error.  We now ignore
these errors and default to just repring out the object + datashape