### PR TITLE
Allow DateTimes to be groupers in sql

### DIFF
--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -34,7 +34,7 @@ from ..expr import Projection, Selection, Field, Broadcast, Expr
 from ..expr import (BinOp, UnaryOp, USub, Join, mean, var, std, Reduction,
                     count, FloorDiv, UnaryStringFunction)
 from ..expr import nunique, Distinct, By, Sort, Head, Label, ReLabel, Merge
-from ..expr import common_subexpression, Summary, Like, nelements
+from ..expr import common_subexpression, Summary, Like, nelements, DateTime
 from ..compatibility import reduce
 from .core import compute_up, compute, base
 from ..utils import listpack
@@ -454,7 +454,7 @@ def alias_it(s):
 
 @dispatch(By, Select)
 def compute_up(t, s, **kwargs):
-    if not (isinstance(t.grouper, (Field, Projection))
+    if not (isinstance(t.grouper, (Field, Projection, DateTime))
             or t.grouper is t._child):
         raise ValueError("Grouper must be a projection, got %s" % t.grouper)
 

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -598,16 +598,17 @@ def compute_up(expr, data, **kwargs):
     return sa.extract(expr.attr, data).label(expr._name)
 
 
-@compiles(sa.sql.elements.Extract, 'hive', 'mysql', 'mssql')
-def compile_extract_to_date_function(element, compiler, **kwargs):
+@compiles(sa.sql.elements.Extract, 'hive')
+def hive_extract_to_date_function(element, compiler, **kwargs):
     func = getattr(sa.func, element.field)(element.expr)
     return compiler.visit_function(func, **kwargs)
 
 
-@dispatch((Millisecond, Microsecond),
-          (ClauseElement, sa.sql.elements.ColumnElement))
-def compute_up(expr, data, **kwargs):
-    raise MDNotImplementedError()
+@compiles(sa.sql.elements.Extract, 'mssql')
+def mssql_extract_to_datepart(element, compiler, **kwargs):
+    func = sa.func.datepart(sa.sql.expression.column(element.field),
+                            element.expr)
+    return compiler.visit_function(func, **kwargs)
 
 
 def engine_of(x):


### PR DESCRIPTION
Also adds a default implementation of SQL date functionality

- [x] use `extract` + `compiles` to generalize date access across the various backends