### PR TITLE
Updates the server responses

### DIFF
--- a/blaze/server/client.py
+++ b/blaze/server/client.py
@@ -41,7 +41,7 @@ def reason(response):
     if isinstance(response, flask.Response):
         return response.status
     if isinstance(response, requests.Response):
-        return response.reason
+        return response.text
 
 
 class Client(object):


### PR DESCRIPTION
As discussed in #1043 some of the error messages on the client are cryptic.

This patch updates the the response codes to use more descriptive HTTP codes and pass more data to the user when an exception is raised. 

Example of the new exception:

```
ValueError: Bad response: Computation not supported:
Don't know how to compute:
expr: quandl_vix.head(11)
data: {quandl_vix:    knowledge_date  asof_date   open   high    low  close  volume
0      1990-01-02 1990-01-02  17.24  17.24  17.24  17.24       0   
1      1990-01-03 1990-01-03  18.19  18.19  18.19  18.19       0   
2      1990-01-04 1990-01-04  19.22  19.22  19.22  19.22       0   
3      1990-01-05 1990-01-05  20.11  20.11  20.11  20.11       0   
4      1990-01-08 1990-01-08  20.26  20.26  20.26  20.26       0   
5      1990-01-09 1990-01-09  22.20  22.20  22.20  22.20       0   
6      1990-01-10 1990-01-10  22.44  22.44  22.44  22.44       0   
7      1990-01-11 1990-01-11  20.05  20.05  20.05  20.05       0   
8      1990-01-12 1990-01-12  24.64  24.64  24.64  24.64       0   
9      1990-01-15 1990-01-15  26.34  26.34  26.34  26.34       0   
10     1990-01-16 1990-01-16  24.18  24.18  24.18  24.18       0   
...}
```

The server now shows a difference between a `NotImplementedError` and a random exception by returning the HTTP Not Implemented (501) response code. 