### PR TITLE
Use flask blueprints and application context

### DIFF
--- a/blaze/server/__init__.py
+++ b/blaze/server/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import, division, print_function
 
-from .server import Server, to_tree, from_tree
+from .server import Server, to_tree, from_tree, api
 from .client import ExprClient, Client

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -11,10 +11,11 @@ from contextlib import contextmanager
 import socket
 import json
 from toolz import assoc
-from blaze import into, compute
+from blaze import compute
 from blaze.expr import utils as expr_utils
 from blaze.compute import compute_up
 from datashape.predicates import iscollection, isscalar
+from odo import odo
 from ..interactive import InteractiveSymbol, coerce_scalar
 from ..utils import json_dumps
 from ..expr import Expr, symbol
@@ -281,7 +282,7 @@ def compserver():
         result = compute(expr, {leaf: dataset})
 
         if iscollection(expr.dshape):
-            result = into(list, result)
+            result = odo(result, list)
         elif isscalar(expr.dshape):
             result = coerce_scalar(result, str(expr.dshape))
     except NotImplementedError as e:

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 try:
     import flask
-    from flask import Flask, request
+    from flask import Blueprint, Flask, request
 except ImportError:
     pass
 
@@ -10,7 +10,6 @@ import blaze
 import socket
 import json
 from toolz import assoc
-from functools import partial, wraps
 from blaze import into, compute
 from blaze.expr import utils as expr_utils
 from blaze.compute import compute_up
@@ -27,6 +26,9 @@ __all__ = 'Server', 'to_tree', 'from_tree'
 # http://www.speedguide.net/port.php?port=6363
 # http://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
 DEFAULT_PORT = 6363
+
+
+api = Blueprint('api', __name__)
 
 
 class Server(object):
@@ -58,38 +60,30 @@ class Server(object):
 
     def __init__(self, data=None):
         app = self.app = Flask('blaze.server.server')
+        app.register_blueprint(api)
         if data is None:
             data = dict()
         self.data = data
-
-        for args, kwargs, func in routes:
-            func2 = wraps(func)(partial(func, self.data))
-            app.route(*args, **kwargs)(func2)
 
     def run(self, *args, **kwargs):
         """Run the server"""
         port = kwargs.pop('port', DEFAULT_PORT)
         self.port = port
+        app = self.app
         try:
-            self.app.run(*args, port=port, **kwargs)
+            with app.app_context():
+                flask.g.data = self.data
+                self.app.run(*args, port=port, **kwargs)
         except socket.error:
             print("\tOops, couldn't connect on port %d.  Is it busy?" % port)
-            self.run(*args, **assoc(kwargs, 'port', port + 1))
+            if kwargs.get('retry', True):
+                # Attempt to start the server on a new port.
+                self.run(*args, **assoc(kwargs, 'port', port + 1))
 
 
-routes = list()
-
-
-def route(*args, **kwargs):
-    def f(func):
-        routes.append((args, kwargs, func))
-        return func
-    return f
-
-
-@route('/datashape')
-def dataset(data):
-    return str(discover(data))
+@api.route('/datashape')
+def dataset():
+    return str(discover(flask.g.data))
 
 
 def to_tree(expr, names=None):
@@ -261,8 +255,8 @@ def from_tree(expr, namespace=None):
         return expr
 
 
-@route('/compute.json', methods=['POST', 'PUT', 'GET'])
-def compserver(dataset):
+@api.route('/compute.json', methods=['POST', 'PUT', 'GET'])
+def compserver():
     if request.headers['content-type'] != 'application/json':
         return ("Expected JSON data", 415)  # 415: Unsupported Media Type
     try:
@@ -271,6 +265,7 @@ def compserver(dataset):
         return ("Bad JSON.  Got %s " % request.data, 400)  # 400: Bad Request
 
     ns = payload.get('namespace', dict())
+    dataset = flask.g.data
     ns[':leaf'] = symbol('leaf', discover(dataset))
 
     expr = from_tree(payload['expr'], namespace=ns)
@@ -279,17 +274,17 @@ def compserver(dataset):
 
     try:
         result = compute(expr, {leaf: dataset})
+
+        if iscollection(expr.dshape):
+            result = into(list, result)
+        elif isscalar(expr.dshape):
+            result = coerce_scalar(result, str(expr.dshape))
     except NotImplementedError as e:
         # 501: Not Implemented
         return ("Computation not supported:\n%s" % e, 501)
     except Exception as e:
         # 500: Internal Server Error
         return ("Computation failed with message:\n%s" % e, 500)
-
-    if iscollection(expr.dshape):
-        result = into(list, result)
-    elif isscalar(expr.dshape):
-        result = coerce_scalar(result, str(expr.dshape))
 
     return json.dumps({'datashape': str(expr.dshape),
                        'data': result}, default=json_dumps)

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -7,6 +7,7 @@ except ImportError:
     pass
 
 import blaze
+from contextlib import contextmanager
 import socket
 import json
 from toolz import assoc
@@ -65,14 +66,18 @@ class Server(object):
             data = dict()
         self.data = data
 
+    @contextmanager
+    def context(self):
+        with self.app.app_context():
+            flask.g.data = data = self.data
+            yield data
+
     def run(self, *args, **kwargs):
         """Run the server"""
         port = kwargs.pop('port', DEFAULT_PORT)
         self.port = port
-        app = self.app
         try:
-            with app.app_context():
-                flask.g.data = self.data
+            with self.context():
                 self.app.run(*args, port=port, **kwargs)
         except socket.error:
             print("\tOops, couldn't connect on port %d.  Is it busy?" % port)

--- a/blaze/server/tests/fixtures.py
+++ b/blaze/server/tests/fixtures.py
@@ -6,14 +6,13 @@ def make_app_context_fixture(server):
     Create an app_context fixture for a module.
     """
 
-    @pytest.fixture(scope='function')
+    @pytest.yield_fixture
     def app_context(request):
         """
         Fixture to mark that this test uses the flask application
         context.
         """
-        ctx = server.context()
-        request.addfinalizer(lambda: ctx.__exit__(None, None, None))
-        return ctx.__enter__()
+        with server.context() as ctx:
+            yield ctx
 
     return app_context

--- a/blaze/server/tests/fixtures.py
+++ b/blaze/server/tests/fixtures.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def make_app_context_fixture(server):
+    """
+    Create an app_context fixture for a module.
+    """
+
+    @pytest.fixture(scope='function')
+    def app_context(request):
+        """
+        Fixture to mark that this test uses the flask application
+        context.
+        """
+        ctx = server.context()
+        request.addfinalizer(lambda: ctx.__exit__(None, None, None))
+        return ctx.__enter__()
+
+    return app_context

--- a/blaze/server/tests/test_client.py
+++ b/blaze/server/tests/test_client.py
@@ -8,8 +8,10 @@ from blaze import compute, Data, by, into, discover
 from blaze.expr import Expr, symbol, Field
 from blaze.dispatch import dispatch
 from blaze.server import Server
-from blaze.server.index import parse_index, emit_index
 from blaze.server.client import Client, resource
+
+from blaze.server.tests.fixtures import make_app_context_fixture
+
 
 df = DataFrame([['Alice', 100], ['Bob', 200]],
                columns=['name', 'amount'])
@@ -27,15 +29,7 @@ from blaze.server import client
 client.requests = test # OMG monkey patching
 
 
-@pytest.fixture(scope='function')
-def app_context(request):
-    """
-    Fixture to mark that this test uses the flask application
-    context.
-    """
-    ctx = server.context()
-    request.addfinalizer(lambda: ctx.__exit__(None, None, None))
-    return ctx.__enter__()
+app_context = make_app_context_fixture(server)
 
 
 def test_client(app_context):

--- a/blaze/server/tests/test_server.py
+++ b/blaze/server/tests/test_server.py
@@ -156,14 +156,12 @@ def dont_test_compute_with_namespace(app_context):
     assert json.loads(response.data.decode('utf-8'))['data'] == expected
 
 
-@pytest.fixture
+@pytest.yield_fixture
 def iris_server(request):
     iris = CSV(example('iris.csv'))
     server = Server(iris)
-    ctx = server.context()
-    request.addfinalizer(lambda: ctx.__exit__(None, None, None))
-    ctx.__enter__()
-    return server.app.test_client()
+    with server.context():
+        yield server.app.test_client()
 
 
 iris = CSV(example('iris.csv'))

--- a/docs/source/scripts/capabilities.py
+++ b/docs/source/scripts/capabilities.py
@@ -92,7 +92,7 @@ capabilities = {
 colormap = {True: "#5EDA9E", False: "#FFFFFF"}
 
 backends = sorted(capabilities.keys())
-operations = sorted(capabilities.values()[0].keys())
+operations = sorted(tuple(capabilities.values())[0].keys())
 
 statuses = [capabilities[backend][op] for backend in backends
             for op in operations]

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -267,6 +267,27 @@ or a Blaze server
    >>> server = Server(cached)  # doctest: +SKIP
 
 
+Flask Blueprint
+---------------
+
+If you would like to use the blaze server endpoints from within another flask
+application, you can register the blaze api blueprint with your app. For
+example:
+
+.. code-block:: python
+
+   >>> from blaze.server import api  # doctest: +SKIP
+   >>> app.register_blueprint(api)  # doctest: +SKIP
+   >>> with app.app_context():  # doctest: +SKIP
+   >>>     flask.g.data = dset  # doctest: +SKIP
+   >>>     app.run()  # doctest: +SKIP
+
+
+When using the blaze flask blueprint, be sure to register your dataset in the
+flask application context ``flask.g`` so that it is available to the API
+endpoints.
+
+
 Conclusion
 ==========
 


### PR DESCRIPTION
By using blueprints, users can add these routes to another flask application as long as they register the data in the application context.