### PR TITLE
Use boundmethods instead of partials binding self

### DIFF
--- a/blaze/compatibility.py
+++ b/blaze/compatibility.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import sys
+from types import MethodType
 
 PY3 = sys.version_info[0] == 3
 PY2 = sys.version_info[0] == 2
@@ -46,11 +47,15 @@ if PY2:
     unicode = builtins.unicode
     basestring = builtins.basestring
     _strtypes = (str, unicode)
+
+    def boundmethod(func, instance):
+        return MethodType(func, instance, type(instance))
 else:
     _inttypes = (int,)
     _strtypes = (str,)
     unicode = str
     basestring = str
+    boundmethod = MethodType
 
 
 import io

--- a/blaze/expr/expressions.py
+++ b/blaze/expr/expressions.py
@@ -13,7 +13,7 @@ import re
 from datashape import dshape, DataShape, Record, Var, Mono, Fixed
 from datashape.predicates import isscalar, iscollection, isboolean, isrecord
 
-from ..compatibility import _strtypes, builtins
+from ..compatibility import _strtypes, builtins, boundmethod
 from .core import Node, subs, common_subexpression, path
 from .method_dispatch import select_functions
 from ..dispatch import dispatch
@@ -179,8 +179,7 @@ class Expr(Node):
                     if func in method_properties:
                         result = func(self)
                     else:
-                        result = functools.update_wrapper(partial(func, self),
-                                                          func)
+                        result = boundmethod(func, self)
                 else:
                     raise
         _attr_cache[(self, key)] = result

--- a/blaze/tests/test_interactive.py
+++ b/blaze/tests/test_interactive.py
@@ -12,6 +12,7 @@ from blaze.utils import tmpfile, example
 from blaze.compatibility import xfail
 import pytest
 import sys
+from types import MethodType
 
 import pandas as pd
 import pandas.util.testing as tm
@@ -373,3 +374,20 @@ def test_asarray_fails_on_different_column_names():
 def test_data_does_not_accept_columns_kwarg():
     with pytest.raises(ValueError):
         Data([(1, 2), (3, 4)], columns=list('ab'))
+
+
+def test_functions_as_bound_methods():
+    """
+    Test that all functions on an InteractiveSymbol are instance methods
+    of that object.
+    """
+    # Filter out __class__ and friends that are special, these can be
+    # callables without being instance methods.
+    callable_attrs = filter(
+        callable,
+        (getattr(t, a, None) for a in dir(t) if not a.startswith('__')),
+    )
+    for attr in callable_attrs:
+        assert isinstance(attr, MethodType)
+        # Make sure this is bound to the correct object.
+        assert attr.__self__ is t


### PR DESCRIPTION
Currently, the `__getattr__` of `InteractiveSymbol` returns `functools.partial` instances that bind `self` to a function. This can be sort of confusing because:

```python
In [4]: ds.apply
Out[4]: 
functools.partial(<function apply at 0x7f5eec192d08>, Data:       Engine(postgresql://localhost/bz)
DataShape:  {
  571980fb9b6b46bcab732e02ba9c854d: var * {
    asof_date: datetime,
    open: ?float64,
    high: ?float64,
    low: ?float64,
    close: ?float64,
  ...)

In [5]: type(ds.apply)
Out[5]: functools.partial
```
Also, this causes the `?` operator in IPython to return the docs for `functools.partial` instead of the function being wrapped.

With this change:

```python
In [3]: ds.apply
Out[3]: 
<bound method InteractiveSymbol.apply of Data:       Engine(postgresql://localhost/bz)
DataShape:  {
  571980fb9b6b46bcab732e02ba9c854d: var * {
    asof_date: datetime,
    open: ?float64,
    high: ?float64,
    low: ?float64,
    close: ?float64,
  ...>

In [4]: type(ds.apply)
Out[4]: method
```
This causes the `?` to resolve correctly.