### PR TITLE
Fix unary operations in sql backend

### DIFF
--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -25,7 +25,7 @@ from copy import copy
 import sqlalchemy as sa
 
 from sqlalchemy import sql, Table, MetaData
-from sqlalchemy.sql import Selectable, Select
+from sqlalchemy.sql import Selectable, Select, functions as safuncs
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.elements import ClauseElement, ColumnElement
 from sqlalchemy.engine import Engine
@@ -141,11 +141,8 @@ def binop_sql(t, lhs, rhs, **kwargs):
 
 @dispatch(UnaryOp, ColumnElement)
 def compute_up(t, s, **kwargs):
-    try:
-        return t.op(s)
-    except AttributeError:
-        symbol = t.symbol
-        return getattr(sa.sql.functions, symbol, getattr(sa.func, symbol))(s)
+    sym = t.symbol
+    return getattr(t, 'op', getattr(safuncs, sym, getattr(sa.func, sym)))(s)
 
 
 @dispatch(Selection, Select)

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -141,13 +141,11 @@ def binop_sql(t, lhs, rhs, **kwargs):
 
 @dispatch(UnaryOp, ColumnElement)
 def compute_up(t, s, **kwargs):
-    op = getattr(sa.func, t.symbol)
-    return op(s)
-
-
-@dispatch(USub, (sa.Column, Selectable))
-def compute_up(t, s, **kwargs):
-    return -s
+    try:
+        return t.op(s)
+    except AttributeError:
+        symbol = t.symbol
+        return getattr(sa.sql.functions, symbol, getattr(sa.func, symbol))(s)
 
 
 @dispatch(Selection, Select)

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -1495,3 +1495,16 @@ def test_do_not_erase_group_by_functions_with_datetime():
         extract(date from accdate.occurred_on)
     """
     assert normalize(result) == normalize(expected)
+
+
+def test_not():
+    expr = t.amount[~t.name.isin(('Billy', 'Bob'))]
+    result = str(compute(expr, s))
+    expected = """SELECT
+        accounts.amount
+    FROM
+        accounts
+    WHERE
+        accounts.name not in (:name_1, :name_2)
+    """
+    assert normalize(result) == normalize(expected)

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -133,7 +133,7 @@ def test_arithmetic():
         str(2 * s.c.amount)
 
     assert (str(compute(~(t['amount'] > 10), s, post_compute=False)) ==
-            "~(accounts.amount > :amount_1)")
+            "accounts.amount <= :amount_1")
 
     assert str(compute(t['amount'] + t['id'] * 2, s)) == \
         str(sa.select([s.c.amount + s.c.id * 2]))

--- a/blaze/expr/arithmetic.py
+++ b/blaze/expr/arithmetic.py
@@ -377,6 +377,7 @@ class Not(UnaryOp):
     symbol = '~'
     op = operator.invert
     _dtype = ct.bool_
+
     def __str__(self):
         return '~%s' % parenthesize(eval_str(self._child))
 


### PR DESCRIPTION
fixes unary Not, which was showing up as `~` in all sql queries