### PR TITLE
ENH: Allows the server/client to use pickle

### DIFF
--- a/blaze/compatibility.py
+++ b/blaze/compatibility.py
@@ -16,6 +16,12 @@ else:
     apply = builtins.apply
 
 
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+
 # Portions of this taken from the six library, licensed as follows.
 #
 # Copyright (c) 2010-2013 Benjamin Peterson

--- a/blaze/server/__init__.py
+++ b/blaze/server/__init__.py
@@ -2,4 +2,21 @@ from __future__ import absolute_import, division, print_function
 
 from .server import Server, to_tree, from_tree, api
 from .client import ExprClient, Client
-from .serialization import json as json_format, pickle as pickle_format
+from .serialization import (
+    all_formats,
+    json as json_format,
+    pickle as pickle_format,
+)
+
+
+__all__ = [
+    'Client',
+    'ExprClient',
+    'Server',
+    'all_formats',
+    'api',
+    'from_tree',
+    'json_format',
+    'pickle_format',
+    'to_tree',
+]

--- a/blaze/server/__init__.py
+++ b/blaze/server/__init__.py
@@ -2,3 +2,4 @@ from __future__ import absolute_import, division, print_function
 
 from .server import Server, to_tree, from_tree, api
 from .client import ExprClient, Client
+from .serialization import json as json_format, pickle as pickle_format

--- a/blaze/server/serialization.py
+++ b/blaze/server/serialization.py
@@ -1,0 +1,27 @@
+from collections import namedtuple
+from functools import partial
+import json as json_module
+
+from ..compatibility import pickle, unicode
+from ..utils import json_dumps
+
+
+SerializationFormat = namedtuple('SerializationFormat', 'name loads dumps')
+
+
+def _coerce_str(bytes_or_str):
+    if isinstance(bytes_or_str, unicode):
+        return bytes_or_str
+    return bytes_or_str.decode('utf-8')
+
+
+json = SerializationFormat(
+    'json',
+    lambda data: json_module.loads(_coerce_str(data)),
+    partial(json_module.dumps, default=json_dumps),
+)
+pickle = SerializationFormat(
+    'pickle',
+    pickle.loads,
+    partial(pickle.dumps, protocol=pickle.HIGHEST_PROTOCOL),
+)

--- a/blaze/server/serialization.py
+++ b/blaze/server/serialization.py
@@ -25,3 +25,16 @@ pickle = SerializationFormat(
     pickle.loads,
     partial(pickle.dumps, protocol=pickle.HIGHEST_PROTOCOL),
 )
+
+
+all_formats = (
+    json,
+    pickle,
+)
+
+
+__all__ = [
+    'all_formats',
+    'json',
+    'pickle',
+]

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -50,9 +50,9 @@ def _register_api(app, options, first_registration=False):
     Register the data with the blueprint.
     """
     _get_data.cache[app] = _get_option('data', options)
-    _get_format.cache[app] = {
-        f.name: f for f in _get_option('formats', options)
-    }
+    _get_format.cache[app] = dict(
+        (f.name, f) for f in _get_option('formats', options)
+    )
     # Call the original register function.
     Blueprint.register(api, app, options, first_registration)
 

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -1,11 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import socket
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
-import json
 
 import flask
 from flask import Blueprint, Flask, request
@@ -20,8 +15,8 @@ from blaze import compute
 from blaze.expr import utils as expr_utils
 from blaze.compute import compute_up
 
+from .serialization import json
 from ..interactive import InteractiveSymbol, coerce_scalar
-from ..utils import json_dumps
 from ..expr import Expr, symbol
 
 from datashape import Mono, discover
@@ -38,16 +33,26 @@ api = Blueprint('api', __name__)
 pickle_extension_api = Blueprint('pickle_extension_api', __name__)
 
 
+def _get_option(option, options):
+    try:
+        return options[option]
+    except KeyError:
+        # Provides a more informative error message.
+        raise TypeError(
+            'The blaze api must be registered with {option}'.format(
+                option=option,
+            ),
+        )
+
+
 def _register_api(app, options, first_registration=False):
     """
     Register the data with the blueprint.
     """
-    try:
-        _get_data.cache[app] = options['data']
-    except KeyError:
-        # Provides a more informative error message.
-        raise TypeError('The blaze api must be registered with data')
-
+    _get_data.cache[app] = _get_option('data', options)
+    _get_format.cache[app] = {
+        f.name: f for f in _get_option('formats', options)
+    }
     # Call the original register function.
     Blueprint.register(api, app, options, first_registration)
 
@@ -63,6 +68,11 @@ def _get_data():
 _get_data.cache = {}
 
 
+def _get_format(name):
+    return _get_format.cache[flask.current_app][name]
+_get_format.cache = {}
+
+
 class Server(object):
 
     """ Blaze Data Server
@@ -74,6 +84,12 @@ class Server(object):
     data : ``dict`` or ``None``, optional
         A dictionary mapping dataset name to any data format that blaze
         understands.
+
+    formats : ``iterable[SerializationFormat]``, optional
+        An iterable of supported serialization formats. By default, the
+        server will support JSON.
+        A serialization format is an object that supports:
+        name, loads, and dumps.
 
     Examples
     --------
@@ -90,13 +106,15 @@ class Server(object):
     """
     __slots__ = 'app', 'data', 'port'
 
-    def __init__(self, data=None, allow_pickle=False):
+    def __init__(self, data=None, formats=None):
         app = self.app = Flask('blaze.server.server')
         if data is None:
             data = dict()
-        app.register_blueprint(api, data=data)
-        if allow_pickle:
-            app.register_blueprint(pickle_extension_api)
+        app.register_blueprint(
+            api,
+            data=data,
+            formats=formats if formats is not None else (json,),
+        )
         self.data = data
 
     def run(self, *args, **kwargs):
@@ -286,14 +304,15 @@ def from_tree(expr, namespace=None):
         return expr
 
 
-@api.route('/compute.json', methods=['POST', 'PUT', 'GET'])
-def compserver(serial=json):
-    if serial is json:
-        data = request.data.encode('utf-8')
-    else:
-        data = request.data
+@api.route('/compute.<serial_format>', methods=['POST', 'PUT', 'GET'])
+def compserver(serial_format):
     try:
-        payload = serial.loads(data)
+        serial = _get_format(serial_format)
+    except KeyError:
+        return 'Unsupported serialization format', 404
+
+    try:
+        payload = serial.loads(request.data)
     except ValueError:
         return ("Bad data.  Got %s " % request.data, 400)  # 400: Bad Request
 
@@ -319,12 +338,4 @@ def compserver(serial=json):
         # 500: Internal Server Error
         return ("Computation failed with message:\n%s" % e, 500)
 
-    return serial.dumps(
-        {'datashape': str(expr.dshape), 'data': result},
-        **({'default': json_dumps} if serial is json else {})
-    )
-
-
-@pickle_extension_api.route('/compute.pickle', methods=['POST', 'PUT', 'GET'])
-def comppickle():
-    return compserver(pickle)
+    return serial.dumps({'datashape': str(expr.dshape), 'data': result})

--- a/blaze/server/tests/test_server.py
+++ b/blaze/server/tests/test_server.py
@@ -14,6 +14,7 @@ from odo import odo
 from blaze.utils import example
 from blaze import discover, symbol, by, CSV, compute, join, into, resource
 from blaze.server.server import Server, to_tree, from_tree
+from blaze.server.serialization import all_formats
 
 
 accounts = DataFrame([['Alice', 100], ['Bob', 200]],
@@ -33,7 +34,7 @@ data = {'accounts': accounts,
           'events': events,
               'db': db}
 
-server = Server(data)
+server = Server(data, all_formats)
 
 test = server.app.test_client()
 
@@ -43,14 +44,22 @@ def test_datasets():
     assert response.data.decode('utf-8') == str(discover(data))
 
 
-def test_bad_responses():
-    assert 'OK' not in test.post('/compute/accounts.json',
-                                 data = json.dumps(500),
-                                 content_type='application/json').status
-    assert 'OK' not in test.post('/compute/non-existent-table.json',
-                                 data = json.dumps(0),
-                                 content_type='application/json').status
-    assert 'OK' not in test.post('/compute/accounts.json').status
+@pytest.mark.parametrize(
+    'serial',
+    all_formats,
+)
+def test_bad_responses(serial):
+    assert 'OK' not in test.post(
+        '/compute/accounts.{name}'.format(name=serial.name),
+        data=serial.dumps(500),
+    ).status
+    assert 'OK' not in test.post(
+        '/compute/non-existent-table.{name}'.format(name=serial.name),
+        data=serial.dumps(0),
+    ).status
+    assert 'OK' not in test.post(
+        '/compute/accounts.{name}'.format(name=serial.name),
+    ).status
 
 
 def test_to_from_json():
@@ -80,10 +89,14 @@ def test_to_tree():
     assert to_tree(expr) == expected
 
 
-def test_to_tree_slice():
+@pytest.mark.parametrize(
+    'serial',
+    all_formats,
+)
+def test_to_tree_slice(serial):
     t = symbol('t', 'var * {name: string, amount: int32}')
     expr = t[:5]
-    expr2 = pipe(expr, to_tree, json.dumps, json.loads, from_tree)
+    expr2 = pipe(expr, to_tree, serial.dumps, serial.loads, from_tree)
     assert expr.isidentical(expr2)
 
 
@@ -110,143 +123,195 @@ def test_from_tree_is_robust_to_unnecessary_namespace():
 t = symbol('t', discover(data))
 
 
-def test_compute():
+@pytest.mark.parametrize(
+    'serial',
+    all_formats,
+)
+def test_compute(serial):
     expr = t.accounts.amount.sum()
     query = {'expr': to_tree(expr)}
     expected = 300
 
-    response = test.post('/compute.json',
-                         data = json.dumps(query),
-                         content_type='application/json')
+    response = test.post(
+        '/compute.{name}'.format(name=serial.name),
+        data=serial.dumps(query),
+    )
 
     assert 'OK' in response.status
-    assert json.loads(response.data.decode('utf-8'))['data'] == expected
+    assert serial.loads(response.data)['data'] == expected
 
 
-def test_get_datetimes():
+@pytest.mark.parametrize(
+    'serial',
+    all_formats,
+)
+def test_get_datetimes(serial):
     expr = t.events
     query = {'expr': to_tree(expr)}
 
-    response = test.post('/compute.json',
-                         data=json.dumps(query),
-                         content_type='application/json')
+    response = test.post(
+        '/compute.{name}'.format(name=serial.name),
+        data=serial.dumps(query),
+    )
 
     assert 'OK' in response.status
-    data = json.loads(response.data.decode('utf-8'))
+    data = serial.loads(response.data)
     ds = datashape.dshape(data['datashape'])
     result = into(np.ndarray, data['data'], dshape=ds)
     assert into(list, result) == into(list, events)
 
 
-def dont_test_compute_with_namespace():
+@pytest.mark.parametrize(
+    'serial',
+    all_formats,
+)
+def dont_test_compute_with_namespace(serial):
     query = {'expr': {'op': 'Field',
                       'args': ['accounts', 'name']}}
     expected = ['Alice', 'Bob']
 
-    response = test.post('/compute/accounts.json',
-                         data = json.dumps(query),
-                         content_type='application/json')
+    response = test.post(
+        '/compute/accounts.{name}'.format(name=serial.name),
+        data=serial.dumps(query),
+    )
 
     assert 'OK' in response.status
-    assert json.loads(response.data.decode('utf-8'))['data'] == expected
+    assert serial.loads(response.data)['data'] == expected
 
 
 @pytest.fixture
 def iris_server(request):
     iris = CSV(example('iris.csv'))
-    return Server(iris).app.test_client()
+    return Server(iris, all_formats).app.test_client()
 
 
 iris = CSV(example('iris.csv'))
 
 
-def test_compute_with_variable_in_namespace(iris_server):
+@pytest.mark.parametrize(
+    'serial',
+    all_formats,
+)
+def test_compute_with_variable_in_namespace(iris_server, serial):
     test = iris_server
     t = symbol('t', discover(iris))
     pl = symbol('pl', 'float32')
     expr = t[t.petal_length > pl].species
     tree = to_tree(expr, {pl: 'pl'})
 
-    blob = json.dumps({'expr': tree, 'namespace': {'pl': 5}})
-    resp = test.post('/compute.json', data=blob,
-                     content_type='application/json')
+    blob = serial.dumps({'expr': tree, 'namespace': {'pl': 5}})
+    resp = test.post(
+        '/compute.{name}'.format(name=serial.name),
+        data=blob,
+    )
 
     assert 'OK' in resp.status
-    result = json.loads(resp.data.decode('utf-8'))['data']
+    result = serial.loads(resp.data)['data']
     expected = list(compute(expr._subs({pl: 5}), {t: iris}))
     assert result == expected
 
 
-def test_compute_by_with_summary(iris_server):
+@pytest.mark.parametrize(
+    'serial',
+    all_formats,
+)
+def test_compute_by_with_summary(iris_server, serial):
     test = iris_server
     t = symbol('t', discover(iris))
-    expr = by(t.species, max=t.petal_length.max(),
-                         sum=t.petal_width.sum())
+    expr = by(
+        t.species,
+        max=t.petal_length.max(),
+        sum=t.petal_width.sum(),
+    )
     tree = to_tree(expr)
-    blob = json.dumps({'expr': tree})
-    resp = test.post('/compute.json', data=blob,
-                     content_type='application/json')
+    blob = serial.dumps({'expr': tree})
+    resp = test.post(
+        '/compute.{name}'.format(name=serial.name),
+        data=blob,
+    )
     assert 'OK' in resp.status
-    result = json.loads(resp.data.decode('utf-8'))['data']
-    expected = compute(expr, iris)
-    assert result == list(map(list, into(list, expected)))
+    result = DataFrame(serial.loads(resp.data)['data']).values
+    expected = compute(expr, iris).values
+    np.testing.assert_array_equal(result[:, 0], expected[:, 0])
+    np.testing.assert_array_almost_equal(result[:, 1:], expected[:, 1:])
 
 
-def test_compute_column_wise(iris_server):
+@pytest.mark.parametrize(
+    'serial',
+    all_formats,
+)
+def test_compute_column_wise(iris_server, serial):
     test = iris_server
     t = symbol('t', discover(iris))
     subexpr = ((t.petal_width / 2 > 0.5) &
                (t.petal_length / 2 > 0.5))
     expr = t[subexpr]
     tree = to_tree(expr)
-    blob = json.dumps({'expr': tree})
-    resp = test.post('/compute.json', data=blob,
-                     content_type='application/json')
+    blob = serial.dumps({'expr': tree})
+    resp = test.post(
+        '/compute.{name}'.format(name=serial.name),
+        data=blob,
+    )
 
     assert 'OK' in resp.status
-    result = json.loads(resp.data.decode('utf-8'))['data']
+    result = serial.loads(resp.data)['data']
     expected = compute(expr, iris)
     assert list(map(tuple, result)) == into(list, expected)
 
 
-def test_multi_expression_compute():
+@pytest.mark.parametrize(
+    'serial',
+    all_formats,
+)
+def test_multi_expression_compute(serial):
     s = symbol('s', discover(data))
 
     expr = join(s.accounts, s.cities)
 
-    resp = test.post('/compute.json',
-                     data=json.dumps({'expr': to_tree(expr)}),
-                     content_type='application/json')
+    resp = test.post(
+        '/compute.{name}'.format(name=serial.name),
+        data=serial.dumps({'expr': to_tree(expr)}),
+    )
 
     assert 'OK' in resp.status
-    result = json.loads(resp.data.decode('utf-8'))['data']
+    result = serial.loads(resp.data)['data']
     expected = compute(expr, {s: data})
 
-    assert list(map(tuple, result))== into(list, expected)
+    assert list(map(tuple, result)) == into(list, expected)
 
 
-def test_leaf_symbol():
+@pytest.mark.parametrize(
+    'serial',
+    all_formats,
+)
+def test_leaf_symbol(serial):
     query = {'expr': {'op': 'Field', 'args': [':leaf', 'cities']}}
-    resp = test.post('/compute.json',
-                     data=json.dumps(query),
-                     content_type='application/json')
+    resp = test.post(
+        '/compute.{name}'.format(name=serial.name),
+        data=serial.dumps(query),
+    )
 
-    a = json.loads(resp.data.decode('utf-8'))['data']
+    a = serial.loads(resp.data)['data']
     b = into(list, cities)
 
     assert list(map(tuple, a)) == b
 
 
-def test_sqlalchemy_result():
+@pytest.mark.parametrize(
+    'serial',
+    all_formats,
+)
+def test_sqlalchemy_result(serial):
     expr = t.db.iris.head(5)
     query = {'expr': to_tree(expr)}
 
-    response = test.post('/compute.json',
-                         data = json.dumps(query),
-                         content_type='application/json')
+    response = test.post(
+        '/compute.{name}'.format(name=serial.name),
+        data=serial.dumps(query),
+    )
 
     assert 'OK' in response.status
-    result = json.loads(response.data.decode('utf-8'))['data']
+    result = serial.loads(response.data)['data']
     assert all(isinstance(item, (tuple, list)) for item in result)
 
 
@@ -254,12 +319,33 @@ def test_server_accepts_non_nonzero_ables():
     Server(DataFrame())
 
 
-def test_server_can_compute_sqlalchemy_reductions():
+@pytest.mark.parametrize(
+    'serial',
+    all_formats,
+)
+def test_server_can_compute_sqlalchemy_reductions(serial):
     expr = t.db.iris.petal_length.sum()
     query = {'expr': to_tree(expr)}
-    response = test.post('/compute.json',
-                         data=json.dumps(query),
-                         content_type='application/json')
+    response = test.post(
+        '/compute.{name}'.format(name=serial.name),
+        data=serial.dumps(query),
+    )
     assert 'OK' in response.status
-    result = json.loads(response.data.decode('utf-8'))['data']
+    result = serial.loads(response.data)['data']
+    assert result == odo(compute(expr, {t: data}), int)
+
+
+@pytest.mark.parametrize(
+    'serial',
+    all_formats,
+)
+def test_serialization_endpoints(serial):
+    expr = t.db.iris.petal_length.sum()
+    query = {'expr': to_tree(expr)}
+    response = test.post(
+        '/compute.{name}'.format(name=serial.name),
+        data=serial.dumps(query),
+    )
+    assert 'OK' in response.status
+    result = serial.loads(response.data)['data']
     assert result == odo(compute(expr, {t: data}), int)


### PR DESCRIPTION
When trying to use the blaze server, you are heavily restricted in what kind of data you can work with because of the json protocol. The main thing that I needed was a clean way to send datetimes across the wire. To generalize the solution, I have just allowed (not forced) the client/server to use pickle. I realize most people would probably be afraid to unpickle data from the internet; however, blaze server is basically remote code execution by definition. The server will only respond to 'compute.pickle' if the `allow_pickle` flag is set, this is by default false.