### PR TITLE
ENH: Adds datetime arithmetic with timedeltas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ matrix:
     - python: 3.3
     - python: 3.4
 
-branches:
-  only:
-    - master
-
 services:
     - mongodb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ branches:
 services:
     - mongodb
 
+addons:
+  postgresql: "9.3"
+
 
 # Note: conda is not available for anything but python 2.7. So below we try to install
 # conda in 2.7 and use conda to install dependencies in the virtualenv for version x.y
@@ -67,6 +70,7 @@ install:
 before_script:
   - sleep 15
   - "mongo admin --eval 'db.runCommand({setParameter: 1, textSearchEnabled: true});'"
+  - psql -c "create database test;" -U postgres
 
 script:
   - echo '[pytest]' > pytest.ini

--- a/blaze/compute/numpy.py
+++ b/blaze/compute/numpy.py
@@ -45,7 +45,6 @@ try:
     from .numba import broadcast_numba as broadcast_ndarray
 except ImportError:
     def broadcast_ndarray(t, *data, **kwargs):
-        scope = kwargs.pop('scope')
         d = dict(zip(t._scalar_expr._leaves(), data))
         return compute(t._scalar_expr, d, **kwargs)
 

--- a/blaze/compute/tests/test_numpy_compute.py
+++ b/blaze/compute/tests/test_numpy_compute.py
@@ -459,3 +459,11 @@ def test_str_interp():
     s = symbol('s', discover(a))
     expr = s.interp(1)
     assert all(compute(expr, a) == np.char.mod(a, 1))
+
+
+def test_timedelta_arith():
+    dates = np.arange('2014-01-01', '2014-02-01', dtype='datetime64')
+    delta = np.timedelta64(1, 'D')
+    sym = symbol('s', discover(dates))
+    assert (compute(sym + delta, dates) == dates + delta).all()
+    assert (compute(sym - delta, dates) == dates - delta).all()

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import pandas as pd
 import pandas.util.testing as tm
 import numpy as np
@@ -689,3 +689,11 @@ def test_str_interp():
     s = symbol('s', "3 * string[1, 'U32']")
     expr = s.interp(1)
     assert (compute(expr, a) == (a % 1)).all()
+
+
+def test_timedelta_arith():
+    series = Series(pd.date_range('2014-01-01', '2014-02-01'))
+    sym = symbol('s', '32 * datetime')
+    delta = timedelta(days=1)
+    assert (compute(sym + delta, series) == series + delta).all()
+    assert (compute(sym - delta, series) == series - delta).all()

--- a/blaze/compute/tests/test_pandas_compute.py
+++ b/blaze/compute/tests/test_pandas_compute.py
@@ -693,7 +693,7 @@ def test_str_interp():
 
 def test_timedelta_arith():
     series = Series(pd.date_range('2014-01-01', '2014-02-01'))
-    sym = symbol('s', '32 * datetime')
+    sym = symbol('s', discover(series))
     delta = timedelta(days=1)
     assert (compute(sym + delta, series) == series + delta).all()
     assert (compute(sym - delta, series) == series - delta).all()

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -1568,7 +1568,7 @@ def sql_with_dts(url):
 def test_timedelta_arith(sql_with_dts):
     delta = timedelta(days=1)
     dates = pd.Series(pd.date_range('2014-01-01', '2014-02-01'))
-    sym = symbol('s', '32 * datetime')
+    sym = symbol('s', discover(dates))
     assert (
         odo(compute(sym + delta, sql_with_dts), pd.Series) == dates + delta
     ).all()

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -46,7 +46,7 @@ def sql(url):
 
 
 def test_postgres_create(sql):
-    assert odo(sql, list)
+    assert odo(sql, list) == [('a', 1), ('b', 2)]
 
 
 @pytest.fixture(scope='module')

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -4,6 +4,7 @@ import pytest
 
 sa = pytest.importorskip('sqlalchemy')
 
+from datetime import timedelta
 import itertools
 import re
 from distutils.version import LooseVersion
@@ -11,8 +12,8 @@ from distutils.version import LooseVersion
 
 import datashape
 from odo import into, resource, drop, odo
+import pandas as pd
 from pandas import DataFrame
-import pandas.util.testing as tm
 from toolz import unique
 
 from blaze.compute.sql import (compute, computefull, select, lower_column,
@@ -1548,3 +1549,29 @@ def test_datetime_to_date():
         accdate
     """
     assert normalize(result) == normalize(expected)
+
+
+@pytest.yield_fixture
+def sql_with_dts(url):
+    try:
+        t = resource(url, dshape='var * {A: datetime}')
+    except sa.exc.OperationalError as e:
+        pytest.skip(str(e))
+    else:
+        t = odo([(d,) for d in pd.date_range('2014-01-01', '2014-02-01')], t)
+        try:
+            yield t
+        finally:
+            drop(t)
+
+
+def test_timedelta_arith(sql_with_dts):
+    delta = timedelta(days=1)
+    dates = pd.Series(pd.date_range('2014-01-01', '2014-02-01'))
+    sym = symbol('s', '32 * datetime')
+    assert (
+        odo(compute(sym + delta, sql_with_dts), pd.Series) == dates + delta
+    ).all()
+    assert (
+        odo(compute(sym - delta, sql_with_dts), pd.Series) == dates - delta
+    ).all()

--- a/blaze/expr/arithmetic.py
+++ b/blaze/expr/arithmetic.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 from datashape import dshape, var, DataShape
 from dateutil.parser import parse as dt_parse
-from datashape.predicates import isscalar, isboolean, isnumeric
+from datashape.predicates import isscalar, isboolean, isnumeric, isdatelike
 from datashape import coretypes as ct, discover, unsigned, promote, optionify
 
 from .core import parenthesize, eval_str
@@ -418,4 +418,5 @@ schema_method_list.extend([
           _rsub, _pow, _rpow, _mod, _rmod,  _neg])),
     (isscalar, set([_eq, _ne, _lt, _le, _gt, _ge])),
     (isboolean, set([_or, _ror, _and, _rand, _invert])),
+    (isdatelike, set([_add, _radd, _sub, _rsub])),
     ])


### PR DESCRIPTION
I wanted to be able to add timedeltas to interactive symbols so I made it so.

```python
In [5]: ds.quandl.vix.knowledge_date
Out[5]: 
   knowledge_date
0      1990-01-02
1      1990-01-03
2      1990-01-04
3      1990-01-05
4      1990-01-08
5      1990-01-09
6      1990-01-10
7      1990-01-11
8      1990-01-12
9      1990-01-15
...

In [6]: ds.quandl.vix.knowledge_date + datetime.timedelta(days=1)
Out[6]: 
   knowledge_date
0      1990-01-03
1      1990-01-04
2      1990-01-05
3      1990-01-06
4      1990-01-09
5      1990-01-10
6      1990-01-11
7      1990-01-12
8      1990-01-13
9      1990-01-16
...
```


datashape already supported this I just needed to add a `_(r)?add` and `_(r)?sub` to isdatelike