### PR TITLE
sql date

### DIFF
--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -740,6 +740,9 @@ def compute_up(expr, data, **kwargs):
 
 @dispatch(DateTime, (ClauseElement, sa.sql.elements.ColumnElement))
 def compute_up(expr, data, **kwargs):
+    if expr.attr == 'date':
+        return sa.func.date(data).label(expr._name)
+
     return sa.extract(expr.attr, data).label(expr._name)
 
 

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -1485,14 +1485,14 @@ def test_do_not_erase_group_by_functions_with_datetime():
               avg_amount=t[t.amount < 0].amount.mean())
     result = str(compute(expr, s))
     expected = """SELECT
-        extract(date from accdate.occurred_on) as occurred_on_date,
+        date(accdate.occurred_on) as occurred_on_date,
         avg(accdate.amount) as avg_amount
     FROM
         accdate
     WHERE
         accdate.amount < :amount_1
     GROUP BY
-        extract(date from accdate.occurred_on)
+        date(accdate.occurred_on)
     """
     assert normalize(result) == normalize(expected)
 
@@ -1506,5 +1506,16 @@ def test_not():
         accounts
     WHERE
         accounts.name not in (:name_1, :name_2)
+    """
+    assert normalize(result) == normalize(expected)
+
+
+def test_datetime_to_date():
+    expr = tdate.occurred_on.date
+    result = str(compute(expr, sdate))
+    expected = """SELECT
+        DATE(accdate.occurred_on) as occurred_on_date
+    FROM
+        accdate
     """
     assert normalize(result) == normalize(expected)


### PR DESCRIPTION
I got errors trying to use the `date` attribute on datetimes with a sql backend. The sql for conversion from datetime to date is not an extract, but a function call. Please let me know if there is a cleaner implementation of this.