### PR TITLE
Adds msgpack as a blaze server serial format

### DIFF
--- a/blaze/server/__init__.py
+++ b/blaze/server/__init__.py
@@ -3,20 +3,24 @@ from __future__ import absolute_import, division, print_function
 from .server import Server, to_tree, from_tree, api
 from .client import ExprClient, Client
 from .serialization import (
+    SerializationFormat,
     all_formats,
     json as json_format,
     pickle as pickle_format,
+    msgpack as msgpack_format,
 )
 
 
 __all__ = [
     'Client',
     'ExprClient',
+    'SerializationFormat',
     'Server',
     'all_formats',
     'api',
     'from_tree',
     'json_format',
+    'msgpack_format',
     'pickle_format',
     'to_tree',
 ]

--- a/blaze/server/serialization.py
+++ b/blaze/server/serialization.py
@@ -2,10 +2,7 @@ from collections import namedtuple
 from functools import partial
 import json as json_module
 
-try:
-    import msgpack as msgpack_module
-except ImportError:
-    msgpack_module = None
+import pandas.msgpack as msgpack_module
 
 from ..compatibility import pickle as pickle_module, unicode
 from ..utils import json_dumps
@@ -30,13 +27,11 @@ pickle = SerializationFormat(
     pickle_module.loads,
     partial(pickle_module.dumps, protocol=pickle_module.HIGHEST_PROTOCOL),
 )
-
-if msgpack_module is not None:
-    msgpack = SerializationFormat(
-        'msgpack',
-        partial(msgpack_module.unpackb, encoding='utf-8'),
-        partial(msgpack_module.packb, default=json_dumps),
-    )
+msgpack = SerializationFormat(
+    'msgpack',
+    partial(msgpack_module.unpackb, encoding='utf-8'),
+    partial(msgpack_module.packb, default=json_dumps),
+)
 
 
 all_formats = frozenset(

--- a/blaze/server/serialization.py
+++ b/blaze/server/serialization.py
@@ -2,7 +2,12 @@ from collections import namedtuple
 from functools import partial
 import json as json_module
 
-from ..compatibility import pickle, unicode
+try:
+    import msgpack as msgpack_module
+except ImportError:
+    msgpack_module = None
+
+from ..compatibility import pickle as pickle_module, unicode
 from ..utils import json_dumps
 
 
@@ -22,19 +27,21 @@ json = SerializationFormat(
 )
 pickle = SerializationFormat(
     'pickle',
-    pickle.loads,
-    partial(pickle.dumps, protocol=pickle.HIGHEST_PROTOCOL),
+    pickle_module.loads,
+    partial(pickle_module.dumps, protocol=pickle_module.HIGHEST_PROTOCOL),
+)
+
+if msgpack_module is not None:
+    msgpack = SerializationFormat(
+        'msgpack',
+        partial(msgpack_module.unpackb, encoding='utf-8'),
+        partial(msgpack_module.packb, default=json_dumps),
+    )
+
+
+all_formats = frozenset(
+    g for _, g in globals().items() if isinstance(g, SerializationFormat)
 )
 
 
-all_formats = (
-    json,
-    pickle,
-)
-
-
-__all__ = [
-    'all_formats',
-    'json',
-    'pickle',
-]
+__all__ = ['all_formats'] + list(f.name for f in all_formats)


### PR DESCRIPTION
The server tests test against this format also because it is in `all_formats`.

Adds the msgpack format as discussed here: https://github.com/ContinuumIO/blaze/issues/982

I didn't see msgpack in the requirements so I made it optional.