### PR TITLE
Properly cast reductions when necessary

### DIFF
--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -362,8 +362,11 @@ def compute_up(t, s, **kwargs):
     # if we're coming from an expression whose dshape doesn't match the dshape
     # of the reduction, we cast for consistent output types across different
     # RDBMSs
-    if t._child.dshape.measure != t.dshape.measure:
-        if t._child.dshape.measure == datashape.bool_:
+    measure = t._child.dshape.measure
+    child_measure = getattr(measure, 'ty', measure)
+    reduction_measure = t.dshape.measure
+    if child_measure != reduction_measure:
+        if child_measure == datashape.bool_:
             cast_type = datashape.int32
         else:
             cast_type = t.dshape.measure

--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -42,14 +42,16 @@ import warnings
 
 from multipledispatch import MDNotImplementedError
 
-from odo.backends.sql import metadata_of_engine
+import datashape
+
+from odo.backends.sql import metadata_of_engine, dshape_to_alchemy
 
 from ..dispatch import dispatch
 
 from .core import compute_up, compute, base
 
 from ..expr import Projection, Selection, Field, Broadcast, Expr, IsIn, Slice
-from ..expr import (BinOp, UnaryOp, USub, Join, mean, var, std, Reduction,
+from ..expr import (BinOp, UnaryOp, Join, mean, var, std, Reduction,
                     count, FloorDiv, UnaryStringFunction, strlen, DateTime)
 from ..expr import nunique, Distinct, By, Sort, Head, Label, ReLabel, Merge
 from ..expr import common_subexpression, Summary, Like, nelements
@@ -344,7 +346,7 @@ def compute_up(t, s, **kwargs):
         op = getattr(sa.sql.functions, t.symbol)
     except AttributeError:
         op = getattr(sa.sql.func, names.get(type(t), t.symbol))
-    return op(s).label(t._name)
+    return op(sa.cast(s, dshape_to_alchemy(t.dshape.measure))).label(t._name)
 
 
 prefixes = {

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -1662,3 +1662,11 @@ def test_insert_from_subselect(sql_with_float):
         odo(sql_with_float, pd.DataFrame).iloc[2:].reset_index(drop=True),
         pd.DataFrame([{'c': 1.0}, {'c': 2.0}]),
     )
+
+
+def test_sum_on_bool_expr():
+    result = compute((t.amount > 1).sum(), s)
+    expected = """SELECT
+            sum(cast(accounts.amount > :amount_1 AS BIGINT)) AS amount_sum
+        FROM accounts"""
+    assert normalize(str(result)) == normalize(expected)

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -1492,7 +1492,7 @@ def test_date_grouper_repeats_not_one_point_oh():
     # FYI spark sql isn't able to parse this correctly
     expected = """SELECT
         EXTRACT(year FROM t.ds) as ds_year,
-        AVG(cast(t.amount as float)) as avg_amt
+        AVG(t.amount) as avg_amt
     FROM t
     GROUP BY EXTRACT(year FROM t.ds)
     """

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -1692,7 +1692,7 @@ def sql_with_float(url):
 @pytest.yield_fixture
 def sql_with_bool(url):
     try:
-        t = resource(url, dshape='var * {c: bool}')
+        t = resource(url, dshape='var * {c: bool, d: ?bool}')
     except sa.exc.OperationalError as e:
         pytest.skip(str(e))
     else:
@@ -1729,8 +1729,9 @@ def test_sum_on_bool_expr():
 
 
 def test_sum_on_bool_expr_compute(sql_with_bool):
-    d = pd.DataFrame(dict(c=np.random.rand(5) > 0.5))
+    d = pd.DataFrame(dict(c=np.random.rand(5) > 0.5,
+                          d=np.random.rand(5) > 0.5))
     s = odo(d, sql_with_bool)
-    result = compute(symbol('t', discover(sql_with_bool)).c.sum(), s).scalar()
-    expected = d.c.sum()
-    assert result == expected
+    t = symbol('t', discover(sql_with_bool))
+    assert compute(t.c.sum(), s).scalar() == d.c.sum()
+    assert compute(t.d.sum(), s).scalar() == d.d.sum()

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -77,38 +77,38 @@ def data():
             's': s}
 
 
-t = symbol('t', 'var * {name: string, amount: int, id: int}')
+t = symbol('t', 'var * {name: string, amount: int64, id: int64}')
 
 metadata = sa.MetaData()
 
 s = sa.Table('accounts', metadata,
              sa.Column('name', sa.String),
-             sa.Column('amount', sa.Integer),
-             sa.Column('id', sa.Integer, primary_key=True))
+             sa.Column('amount', sa.BIGINT),
+             sa.Column('id', sa.BIGINT, primary_key=True))
 
 tdate = symbol('t',
                """var * {
                     name: string,
-                    amount: int,
-                    id: int,
+                    amount: int64,
+                    id: int64,
                     occurred_on: datetime
                 }""")
 
 sdate = sa.Table('accdate', metadata,
                  sa.Column('name', sa.String),
-                 sa.Column('amount', sa.Integer),
-                 sa.Column('id', sa.Integer, primary_key=True),
+                 sa.Column('amount', sa.BIGINT),
+                 sa.Column('id', sa.BIGINT, primary_key=True),
                  sa.Column('occurred_on', sa.DateTime))
 
 
 tbig = symbol('tbig',
-              'var * {name: string, sex: string[1], amount: int, id: int}')
+              'var * {name: string, sex: string[1], amount: int64, id: int64}')
 
 sbig = sa.Table('accountsbig', metadata,
                 sa.Column('name', sa.String),
                 sa.Column('sex', sa.String),
-                sa.Column('amount', sa.Integer),
-                sa.Column('id', sa.Integer, primary_key=True))
+                sa.Column('amount', sa.BIGINT),
+                sa.Column('id', sa.BIGINT, primary_key=True))
 
 
 def normalize(s):
@@ -313,7 +313,7 @@ def test_reductions():
     assert str(compute(sum(t['amount']), s, post_compute=False)) == \
         str(sa.sql.functions.sum(s.c.amount))
     assert str(compute(mean(t['amount']), s, post_compute=False)) == \
-        str(sa.sql.func.avg(s.c.amount))
+        str(sa.sql.func.avg(sa.cast(s.c.amount, sa.FLOAT)))
     assert str(compute(count(t['amount']), s, post_compute=False)) == \
         str(sa.sql.func.count(s.c.amount))
 
@@ -930,7 +930,7 @@ def test_join_on_same_table():
      from tab as tab_left
         join tab as tab_right
         on tab_left.a = tab_right.a)
-    select sum(alias.b) as b_left_sum from alias""")
+    select sum(cast(alias.b as bigint)) as b_left_sum from alias""")
 
     expr = join(t, t, 'a')
     expr = summary(total=expr.a.sum(), smallest=expr.b_right.min())
@@ -938,7 +938,7 @@ def test_join_on_same_table():
     result = compute(expr, {t: T})
 
     assert normalize(str(result)) == normalize("""
-    SELECT min(tab_right.b) as smallest, sum(tab_left.a) as total
+    SELECT min(tab_right.b) as smallest, sum(cast(tab_left.a as bigint)) as total
     FROM tab AS tab_left JOIN tab AS tab_right
     ON tab_left.a = tab_right.a
     """)
@@ -985,13 +985,16 @@ def test_aliased_views_with_two_group_bys():
 
     result = compute(expr2, {bank: sql_bank, cities: sql_cities})
 
-    assert normalize(str(result)) == normalize("""
-    SELECT alias.total, count(alias.name) as count
-    FROM (SELECT bank.name AS name, sum(bank.amount) AS total
-          FROM bank
-          GROUP BY bank.name) as alias
-    GROUP BY alias.total
-    """)
+    assert normalize(str(result)) == normalize("""SELECT
+                alias.total,
+                count(alias.name) as count
+            FROM
+                (SELECT
+                    bank.name AS name,
+                    sum(cast(bank.amount as bigint)) AS total
+              FROM bank
+              GROUP BY bank.name) as alias
+            GROUP BY alias.total""")
 
 
 def test_aliased_views_with_join():
@@ -1001,14 +1004,16 @@ def test_aliased_views_with_join():
 
     result = compute(expr2, {bank: sql_bank, cities: sql_cities})
 
-    assert normalize(str(result)) == normalize("""
-    SELECT alias.total, count(DISTINCT alias.city) AS count
-    FROM (SELECT cities.city AS city, sum(bank.amount) AS total
+    assert normalize(str(result)) == normalize("""SELECT
+                alias.total,
+                count(DISTINCT alias.city) AS count
+        FROM (SELECT
+                cities.city AS city,
+                sum(cast(bank.amount as bigint)) AS total
           FROM bank
-          JOIN cities ON bank.name = cities.name
+              JOIN cities ON bank.name = cities.name
           GROUP BY cities.city) as alias
-    GROUP BY alias.total
-    """)
+    GROUP BY alias.total""")
 
 
 def test_select_field_on_alias():
@@ -1058,22 +1063,35 @@ def test_aliased_views_more():
 
     result = compute(expr, {L: lhs, R: rhs})
 
-    assert normalize(str(result)) == normalize("""
-        SELECT alias.x, alias.y_total, bbb.w, bbb.y
-        FROM (SELECT aaa.x as x, sum(aaa.y) as y_total
+    assert normalize(str(result)) == normalize("""SELECT
+            alias.x,
+            alias.y_total,
+            bbb.w,
+            bbb.y
+        FROM (SELECT
+                aaa.x as x,
+                sum(cast(aaa.y as bigint)) as y_total
               FROM aaa
               GROUP BY aaa.x) AS alias
-        JOIN bbb ON alias.x = bbb.x """)
+        JOIN bbb ON alias.x = bbb.x""")
 
     expr2 = by(expr.w, count=expr.x.count(), total2=expr.y_total.sum())
 
     result2 = compute(expr2, {L: lhs, R: rhs})
 
     assert (
-        normalize(str(result2)) == normalize("""
-            SELECT alias_2.w, count(alias_2.x) as count, sum(alias_2.y_total) as total2
-            FROM (SELECT alias.x, alias.y_total, bbb.w, bbb.y
-                  FROM (SELECT aaa.x as x, sum(aaa.y) as y_total
+        normalize(str(result2)) == normalize("""SELECT
+                alias_2.w,
+                count(alias_2.x) as count,
+                sum(alias_2.y_total) as total2
+            FROM (SELECT
+                    alias.x,
+                    alias.y_total,
+                    bbb.w,
+                    bbb.y
+                  FROM (SELECT
+                            aaa.x as x,
+                            sum(cast(aaa.y as bigint)) as y_total
                         FROM aaa
                         GROUP BY aaa.x) AS alias
                   JOIN bbb ON alias.x = bbb.x) AS alias_2
@@ -1081,9 +1099,13 @@ def test_aliased_views_more():
 
         or
 
-        normalize(str(result2)) == normalize("""
-            SELECT bbb.w, count(alias.x) as count, sum(alias.y_total) as total2
-            FROM (SELECT aaa.x as x, sum(aaa.y) as y_total
+        normalize(str(result2)) == normalize("""SELECT
+                bbb.w,
+                count(alias.x) as count,
+                sum(alias.y_total) as total2
+            FROM (SELECT
+                    aaa.x as x,
+                    sum(cast(aaa.y as bigint)) as y_total
                   FROM aaa
                   GROUP BY aaa.x) as alias
               JOIN bbb ON alias.x = bbb.x
@@ -1449,7 +1471,7 @@ def test_date_grouper_repeats_not_one_point_oh():
     # FYI spark sql isn't able to parse this correctly
     expected = """SELECT
         EXTRACT(year FROM t.ds) as ds_year,
-        AVG(t.amount) as avg_amt
+        AVG(cast(t.amount as float)) as avg_amt
     FROM t
     GROUP BY EXTRACT(year FROM t.ds)
     """
@@ -1530,7 +1552,7 @@ def test_do_not_erase_group_by_functions_with_datetime():
     result = str(compute(expr, s))
     expected = """SELECT
         date(accdate.occurred_on) as occurred_on_date,
-        avg(accdate.amount) as avg_amount
+        avg(cast(accdate.amount as float)) as avg_amount
     FROM
         accdate
     WHERE

--- a/blaze/expr/reductions.py
+++ b/blaze/expr/reductions.py
@@ -114,7 +114,10 @@ class sum(Reduction):
 
     @property
     def schema(self):
-        return DataShape(datashape.maxtype(super(sum, self).schema))
+        if super(sum, self).schema.measure == datashape.bool_:
+            return DataShape(datashape.int64)
+        else:
+            return DataShape(datashape.maxtype(super(sum, self).schema))
 
 
 class max(Reduction):


### PR DESCRIPTION
closes #1050

also restricts the scope of most reductions (notable exceptions are count and nelements)
to only work on sqlalchemy.elements.ColumnElements, rather than the generic ClauseElement.