### PR TITLE
find tables inside non-default schema when serving off a metadata

### DIFF
--- a/blaze/compute/sql.py
+++ b/blaze/compute/sql.py
@@ -757,6 +757,8 @@ def compute_up(expr, data, **kwargs):
 
 @toolz.memoize
 def table_of_metadata(metadata, name):
+    if metadata.schema is not None:
+        name = '.'.join((metadata.schema, name))
     if name not in metadata.tables:
         metadata.reflect(views=metadata.bind.dialect.supports_views)
     return metadata.tables[name]

--- a/docs/source/sql.rst
+++ b/docs/source/sql.rst
@@ -103,4 +103,21 @@ to that database with the following code
 
 One can then query and compute results as with a normal blaze workflow.
 
+
+Connecting to a non-default schema
+----------------------------------
+
+To connect to a non-default schema, one may pass a ``sqlalchemy.MetaData``
+object to ``Data``. For example:
+
+
+.. code-block:: python
+
+   >>> from blaze import Data
+   >>> from sqlalchemy import MetaData
+   >>> ds = Data(MetaData('postgresql://localhost/test', schema='my_schema'))  # doctest: +SKIP
+   >>> ds.dshape  # doctest: +SKIP
+   dshape("{table_a: var * {a: ?int32}, table_b: var * {b: ?int32}}")
+
+
 .. _`Lahman baseball statistics database`: https://github.com/jknecht/baseball-archive-sqlite/raw/master/lahman2013.sqlite


### PR DESCRIPTION
The name of a table include the schema prefix which would disallow us from finding a table in a metadata object if it was not the default schema. This goes with: https://github.com/ContinuumIO/odo/pull/242

The `'.',join` is okay because that is what the key will look like when you have a dotted schema name: 

```python
In [2]: import sqlalchemy as sa

In [3]: ds = bz.Data(sa.MetaData('postgresql://localhost/test', schema='wow.this.sucks'))

In [4]: ds.data.tables
Out[4]: immutabledict({'wow.this.sucks.test': Table('test', MetaData(bind=Engine(postgresql://localhost/test)), Column('a', INTEGER(), table=<test>), schema='wow.this.sucks')})
```