### PR TITLE
Move postgresql tests to their own file

### DIFF
--- a/blaze/compute/tests/test_postgresql_compute.py
+++ b/blaze/compute/tests/test_postgresql_compute.py
@@ -1,0 +1,150 @@
+import itertools
+from datetime import timedelta
+
+import pytest
+
+sa = pytest.importorskip('sqlalchemy')
+pytest.importorskip('psycopg2')
+
+import numpy as np
+import pandas as pd
+
+import pandas.util.testing as tm
+
+from odo import odo, resource, drop, discover
+from blaze import symbol, compute, concat
+
+names = ('tbl%d' % i for i in itertools.count())
+
+
+@pytest.fixture
+def url():
+    return 'postgresql://postgres@localhost/test::%s' % next(names)
+
+
+@pytest.yield_fixture
+def sql(url):
+    try:
+        t = resource(url, dshape='var * {A: string, B: int64}')
+    except sa.exc.OperationalError as e:
+        pytest.skip(str(e))
+    else:
+        t = odo([('a', 1), ('b', 2)], t)
+        try:
+            yield t
+        finally:
+            drop(t)
+
+
+@pytest.yield_fixture
+def sql_with_dts(url):
+    try:
+        t = resource(url, dshape='var * {A: datetime}')
+    except sa.exc.OperationalError as e:
+        pytest.skip(str(e))
+    else:
+        t = odo([(d,) for d in pd.date_range('2014-01-01', '2014-02-01')], t)
+        try:
+            yield t
+        finally:
+            drop(t)
+
+
+@pytest.yield_fixture
+def sql_two_tables():
+    dshape = 'var * {a: int32}'
+    try:
+        t = resource(url(), dshape=dshape)
+        u = resource(url(), dshape=dshape)
+    except sa.exc.OperationalError as e:
+        pytest.skip(str(e))
+    else:
+        try:
+            yield u, t
+        finally:
+            drop(t)
+            drop(u)
+
+
+@pytest.yield_fixture
+def sql_with_float(url):
+    try:
+        t = resource(url, dshape='var * {c: float64}')
+    except sa.exc.OperationalError as e:
+        pytest.skip(str(e))
+    else:
+        try:
+            yield t
+        finally:
+            drop(t)
+
+
+def test_postgres_create(sql):
+    assert odo(sql, list) == [('a', 1), ('b', 2)]
+
+
+def test_postgres_isnan(sql_with_float):
+    data = (1.0,), (float('nan'),)
+    table = odo(data, sql_with_float)
+    sym = symbol('s', discover(data))
+    assert odo(compute(sym.isnan(), table), list) == [(False,), (True,)]
+
+
+def test_insert_from_subselect(sql_with_float):
+    data = pd.DataFrame([{'c': 2.0}, {'c': 1.0}])
+    tbl = odo(data, sql_with_float)
+    s = symbol('s', discover(data))
+    odo(compute(s[s.c.isin((1.0, 2.0))].sort(), tbl), sql_with_float),
+    tm.assert_frame_equal(
+        odo(sql_with_float, pd.DataFrame).iloc[2:].reset_index(drop=True),
+        pd.DataFrame([{'c': 1.0}, {'c': 2.0}]),
+    )
+
+
+def test_concat(sql_two_tables):
+    t_table, u_table = sql_two_tables
+    t_data = pd.DataFrame(np.arange(5), columns=['a'])
+    u_data = pd.DataFrame(np.arange(5, 10), columns=['a'])
+    odo(t_data, t_table)
+    odo(u_data, u_table)
+
+    t = symbol('t', discover(t_data))
+    u = symbol('u', discover(u_data))
+    tm.assert_frame_equal(
+        odo(
+            compute(concat(t, u).sort('a'), {t: t_table, u: u_table}),
+            pd.DataFrame,
+        ),
+        pd.DataFrame(np.arange(10), columns=['a']),
+    )
+
+
+def test_concat_invalid_axis(sql_two_tables):
+    t_table, u_table = sql_two_tables
+    t_data = pd.DataFrame(np.arange(5), columns=['a'])
+    u_data = pd.DataFrame(np.arange(5, 10), columns=['a'])
+    odo(t_data, t_table)
+    odo(u_data, u_table)
+
+    # We need to force the shape to not be a record here so we can
+    # create the `Concat` node with an axis=1.
+    t = symbol('t', '5 * 1 * int32')
+    u = symbol('u', '5 * 1 * int32')
+
+    with pytest.raises(ValueError) as e:
+        compute(concat(t, u, axis=1), {t: t_table, u: u_table})
+
+    # Preserve the suggestion to use merge.
+    assert "'merge'" in str(e.value)
+
+
+def test_timedelta_arith(sql_with_dts):
+    delta = timedelta(days=1)
+    dates = pd.Series(pd.date_range('2014-01-01', '2014-02-01'))
+    sym = symbol('s', discover(dates))
+    assert (
+        odo(compute(sym + delta, sql_with_dts), pd.Series) == dates + delta
+    ).all()
+    assert (
+        odo(compute(sym - delta, sql_with_dts), pd.Series) == dates - delta
+    ).all()

--- a/blaze/compute/tests/test_sql_compute.py
+++ b/blaze/compute/tests/test_sql_compute.py
@@ -4,17 +4,13 @@ import pytest
 
 sa = pytest.importorskip('sqlalchemy')
 
-from datetime import timedelta
 import itertools
 import re
 from distutils.version import LooseVersion
 
 
 import datashape
-import numpy as np
-from odo import into, resource, drop, odo
-import pandas.util.testing as tm
-import pandas as pd
+from odo import into, resource
 from pandas import DataFrame
 from toolz import unique
 
@@ -29,29 +25,6 @@ from blaze.utils import tmpfile
 
 
 names = ('tbl%d' % i for i in itertools.count())
-
-
-@pytest.fixture
-def url():
-    return 'postgresql://postgres@localhost/test::%s' % next(names)
-
-
-@pytest.yield_fixture
-def sql(url):
-    try:
-        t = resource(url, dshape='var * {A: string, B: int64}')
-    except sa.exc.OperationalError as e:
-        pytest.skip(str(e))
-    else:
-        t = odo([('a', 1), ('b', 2)], t)
-        try:
-            yield t
-        finally:
-            drop(t)
-
-
-def test_postgres_create(sql):
-    assert odo(sql, list) == [('a', 1), ('b', 2)]
 
 
 @pytest.fixture(scope='module')
@@ -1613,32 +1586,6 @@ def test_datetime_to_date():
     assert normalize(result) == normalize(expected)
 
 
-@pytest.yield_fixture
-def sql_with_dts(url):
-    try:
-        t = resource(url, dshape='var * {A: datetime}')
-    except sa.exc.OperationalError as e:
-        pytest.skip(str(e))
-    else:
-        t = odo([(d,) for d in pd.date_range('2014-01-01', '2014-02-01')], t)
-        try:
-            yield t
-        finally:
-            drop(t)
-
-
-def test_timedelta_arith(sql_with_dts):
-    delta = timedelta(days=1)
-    dates = pd.Series(pd.date_range('2014-01-01', '2014-02-01'))
-    sym = symbol('s', discover(dates))
-    assert (
-        odo(compute(sym + delta, sql_with_dts), pd.Series) == dates + delta
-    ).all()
-    assert (
-        odo(compute(sym - delta, sql_with_dts), pd.Series) == dates - delta
-    ).all()
-
-
 def test_sort_compose():
     expr = t.name[:5].sort()
     result = compute(expr, s)
@@ -1654,87 +1601,3 @@ def test_sort_compose():
             anon_1.name asc"""
     assert normalize(str(result)) == normalize(expected)
     assert normalize(str(compute(t.sort('name').name[:5], s))) != normalize(expected)
-
-
-@pytest.yield_fixture
-def sql_with_float(url):
-    try:
-        t = resource(url, dshape='var * {c: float64}')
-    except sa.exc.OperationalError as e:
-        pytest.skip(str(e))
-    else:
-        try:
-            yield t
-        finally:
-            drop(t)
-
-
-def test_postgres_isnan(sql_with_float):
-    data = (1.0,), (float('nan'),)
-    table = odo(data, sql_with_float)
-    sym = symbol('s', discover(data))
-    assert odo(compute(sym.isnan(), table), list) == [(False,), (True,)]
-
-
-def test_insert_from_subselect(sql_with_float):
-    data = pd.DataFrame([{'c': 2.0}, {'c': 1.0}])
-    tbl = odo(data, sql_with_float)
-    s = symbol('s', discover(data))
-    odo(compute(s[s.c.isin((1.0, 2.0))].sort(), tbl), sql_with_float),
-    tm.assert_frame_equal(
-        odo(sql_with_float, pd.DataFrame).iloc[2:].reset_index(drop=True),
-        pd.DataFrame([{'c': 1.0}, {'c': 2.0}]),
-    )
-
-
-@pytest.yield_fixture
-def sql_two_tables():
-    dshape = 'var * {a: int32}'
-    try:
-        t = resource(url(), dshape=dshape)
-        u = resource(url(), dshape=dshape)
-    except sa.exc.OperationalError as e:
-        pytest.skip(str(e))
-    else:
-        try:
-            yield u, t
-        finally:
-            drop(t)
-            drop(u)
-
-
-def test_concat(sql_two_tables):
-    t_table, u_table = sql_two_tables
-    t_data = pd.DataFrame(np.arange(5), columns=['a'])
-    u_data = pd.DataFrame(np.arange(5, 10), columns=['a'])
-    odo(t_data, t_table)
-    odo(u_data, u_table)
-
-    t = symbol('t', discover(t_data))
-    u = symbol('u', discover(u_data))
-    tm.assert_frame_equal(
-        odo(
-            compute(concat(t, u).sort('a'), {t: t_table, u: u_table}),
-            pd.DataFrame,
-        ),
-        pd.DataFrame(np.arange(10), columns=['a']),
-    )
-
-
-def test_concat_invalid_axis(sql_two_tables):
-    t_table, u_table = sql_two_tables
-    t_data = pd.DataFrame(np.arange(5), columns=['a'])
-    u_data = pd.DataFrame(np.arange(5, 10), columns=['a'])
-    odo(t_data, t_table)
-    odo(u_data, u_table)
-
-    # We need to force the shape to not be a record here so we can
-    # create the `Concat` node with an axis=1.
-    t = symbol('t', '5 * 1 * int32')
-    u = symbol('u', '5 * 1 * int32')
-
-    with pytest.raises(ValueError) as e:
-        compute(concat(t, u, axis=1), {t: t_table, u: u_table})
-
-    # Preserve the suggestion to use merge.
-    assert "'merge'" in str(e.value)


### PR DESCRIPTION
Allows testing sqlite and other sql tests while allowing us to skip postgresql
tests on machines that don't have psycopg2 installed