### PR TITLE
Remove table spec in Data for blaze Client

### DIFF
--- a/blaze/compute/tests/test_mongo_compute.py
+++ b/blaze/compute/tests/test_mongo_compute.py
@@ -368,3 +368,9 @@ def test_and_same_key(bank):
     result = compute(expr, bank)
     expected = [('Alice', 200), ('Bob', 200)]
     assert result == expected
+
+
+def test_interactive_dshape_works():
+    d = Data('mongodb://localhost:27017/test_db::bank',
+             dshape='var * {name: string, amount: int64}')
+    assert d.dshape == dshape('var * {name: string, amount: int64}')

--- a/blaze/interactive.py
+++ b/blaze/interactive.py
@@ -51,10 +51,7 @@ def Data(data, dshape=None, name=None, fields=None, columns=None, schema=None,
         raise ValueError("Please specify one of schema= or dshape= keyword"
                          " arguments")
 
-    sub_uri = ''
     if isinstance(data, _strtypes):
-        if '::' in data:
-            data, sub_uri = data.split('::')
         data = resource(data, schema=schema, dshape=dshape, columns=columns,
                         **kwargs)
     if (isinstance(data, Iterator) and
@@ -93,14 +90,7 @@ def Data(data, dshape=None, name=None, fields=None, columns=None, schema=None,
             dshape = DataShape(*(dshape.shape + (schema,)))
 
     ds = datashape.dshape(dshape)
-    result = InteractiveSymbol(data, ds, name)
-
-    if sub_uri:
-        for field in sub_uri.split('/'):
-            if field:
-                result = result[field]
-
-    return result
+    return InteractiveSymbol(data, ds, name)
 
 
 class InteractiveSymbol(Symbol):

--- a/blaze/server/__init__.py
+++ b/blaze/server/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from .server import Server, to_tree, from_tree, api
 from .spider import spider, from_yaml
-from .client import ExprClient, Client
+from .client import Client
 from .serialization import (
     SerializationFormat,
     all_formats,
@@ -14,7 +14,6 @@ from .serialization import (
 
 __all__ = [
     'Client',
-    'ExprClient',
     'SerializationFormat',
     'Server',
     'spider',

--- a/blaze/server/client.py
+++ b/blaze/server/client.py
@@ -16,7 +16,7 @@ from .serialization import json
 # flask for testing.  Sadly they have different Response objects,
 # hence the dispatched functions
 
-__all__ = 'Client', 'ExprClient'
+__all__ = 'Client',
 
 
 def content(response):
@@ -88,12 +88,6 @@ class Client(object):
             raise ValueError("Bad Response: %s" % reason(response))
 
         return dshape(content(response).decode('utf-8'))
-
-
-def ExprClient(*args, **kwargs):
-    import warnings
-    warnings.warn("Deprecated use `Client` instead", DeprecationWarning)
-    return Client(*args, **kwargs)
 
 
 @dispatch(Client)

--- a/blaze/server/client.py
+++ b/blaze/server/client.py
@@ -110,11 +110,17 @@ def compute_down(expr, ec, **kwargs):
 
 
 @resource.register('blaze://.+')
-def resource_blaze(uri, **kwargs):
+def resource_blaze(uri, leaf=None, **kwargs):
+    if leaf is not None:
+        raise ValueError('The syntax blaze://...::{leaf} is no longer '
+                         'supported as of version 0.8.1.\n'
+                         'You can access {leaf!r} using this syntax:\n'
+                         'Data({uri})[{leaf!r}]'
+                         .format(leaf=leaf, uri=uri))
     uri = uri[len('blaze://'):]
     sp = uri.split('/')
     tld, rest = sp[0], sp[1:]
     if ':' not in tld:
-        tld = tld + ':%d' % DEFAULT_PORT
+        tld += ':%d' % DEFAULT_PORT
     uri = '/'.join([tld] + list(rest))
     return Client(uri)

--- a/blaze/server/tests/test_client.py
+++ b/blaze/server/tests/test_client.py
@@ -99,6 +99,12 @@ def test_custom_expressions():
     assert list(map(tuple, compute(CustomExpr(t.accounts), ec))) == into(list, df)
 
 
-def test_client_dataset():
+@pytest.mark.xfail(raises=ValueError, reason='No longer support this syntax')
+def test_client_dataset_fails():
     d = Data('blaze://localhost::accounts')
     assert list(map(tuple, into(list, d))) == into(list, df)
+
+
+def test_client_dataset():
+    d = Data('blaze://localhost')
+    assert list(map(tuple, into(list, d.accounts))) == into(list, df)

--- a/blaze/server/tests/test_client.py
+++ b/blaze/server/tests/test_client.py
@@ -99,10 +99,11 @@ def test_custom_expressions():
     assert list(map(tuple, compute(CustomExpr(t.accounts), ec))) == into(list, df)
 
 
-@pytest.mark.xfail(raises=ValueError, reason='No longer support this syntax')
 def test_client_dataset_fails():
-    d = Data('blaze://localhost::accounts')
-    assert list(map(tuple, into(list, d))) == into(list, df)
+    with pytest.raises(ValueError):
+        Data('blaze://localhost::accounts')
+    with pytest.raises(ValueError):
+        resource('blaze://localhost::accounts')
 
 
 def test_client_dataset():


### PR DESCRIPTION
Removes this syntax:

```python
Data('blaze://localhost::accounts')
```
in favor of this

```python
Data('blaze://localhost').accounts
```
so that users are allowed to pass in `dshape` and have it refer to the leaf

closes #1073 