### PR TITLE
Fix tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ recursive-include docs *.rst
 include requirements.txt
 include requirements-strict.txt
 include setup.py
-include README.md
+include README.rst
 include LICENSE.txt
 include MANIFEST.in
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import setuptools
+
 import os
 import sys
 from fnmatch import fnmatch


### PR DESCRIPTION
The `0.8.1` tarball is broken, and `setup.py` cannot be run from it. This fixes it.