### PR TITLE
allow blaze client to disable ssl verification

### DIFF
--- a/blaze/server/client.py
+++ b/blaze/server/client.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
+import warnings
+
+from datashape import dshape
 import flask
 from flask.testing import FlaskClient
-import requests
-
 from odo import resource
-from datashape import dshape
+import requests
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 from ..expr import Expr
 from ..dispatch import dispatch
@@ -32,13 +34,15 @@ def get(client, url, params=None, **kwargs):
         kwargs['verify'] = client.verify_ssl
         kwargs['params'] = params
 
-    return requests.get(
-        '{base}/{url}'.format(
-            base=client.url,
-            url=url,
-        ),
-        **kwargs
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', InsecureRequestWarning)
+        return requests.get(
+            '{base}/{url}'.format(
+                base=client.url,
+                url=url,
+            ),
+            **kwargs
+        )
 
 
 def ok(response):
@@ -89,7 +93,7 @@ class Client(object):
 
     def __init__(self, url, serial=json, verify_ssl=True, **kwargs):
         url = url.strip('/')
-        if not url[:4] == 'http':
+        if not url.startswith('http'):
             url = 'http://' + url
         self.url = url
         self.serial = serial

--- a/blaze/server/client.py
+++ b/blaze/server/client.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import flask
+from flask.testing import FlaskClient
 import requests
 
 from odo import resource
@@ -24,6 +25,20 @@ def content(response):
         return response.data
     if isinstance(response, requests.Response):
         return response.content
+
+
+def get(client, url, params=None, **kwargs):
+    if not isinstance(requests, FlaskClient):
+        kwargs['verify'] = client.verify_ssl
+        kwargs['params'] = params
+
+    return requests.get(
+        '{base}/{url}'.format(
+            base=client.url,
+            url=url,
+        ),
+        **kwargs
+    )
 
 
 def ok(response):
@@ -70,20 +85,20 @@ class Client(object):
 
     blaze.server.server.Server
     """
-    __slots__ = 'url', 'serial'
+    __slots__ = 'url', 'serial', 'verify_ssl'
 
-    def __init__(self, url, serial=json, **kwargs):
+    def __init__(self, url, serial=json, verify_ssl=True, **kwargs):
         url = url.strip('/')
         if not url[:4] == 'http':
             url = 'http://' + url
         self.url = url
         self.serial = serial
+        self.verify_ssl = verify_ssl
 
     @property
     def dshape(self):
         """The datashape of the client"""
-        response = requests.get('%s/datashape' % self.url)
-
+        response = get(self, 'datashape')
         if not ok(response):
             raise ValueError("Bad Response: %s" % reason(response))
 
@@ -101,8 +116,11 @@ def compute_down(expr, ec, **kwargs):
     tree = to_tree(expr)
 
     serial = ec.serial
-    r = requests.post('%s/compute.%s' % (ec.url, serial.name),
-                      data=serial.dumps({'expr': tree}))
+    r = get(
+        ec,
+        'compute.{serial}'.format(serial=serial.name),
+        data=serial.dumps({'expr': tree}),
+    )
 
     if not ok(r):
         raise ValueError("Bad response: %s" % reason(r))

--- a/blaze/server/client.py
+++ b/blaze/server/client.py
@@ -29,20 +29,28 @@ def content(response):
         return response.content
 
 
-def get(client, url, params=None, **kwargs):
+def _request(method, client, url, params=None, **kwargs):
     if not isinstance(requests, FlaskClient):
         kwargs['verify'] = client.verify_ssl
         kwargs['params'] = params
 
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', InsecureRequestWarning)
-        return requests.get(
+        return method(
             '{base}/{url}'.format(
                 base=client.url,
                 url=url,
             ),
             **kwargs
         )
+
+
+def get(*args, **kwargs):
+    return _request(requests.get, *args, **kwargs)
+
+
+def post(*args, **kwargs):
+    return _request(requests.post, *args, **kwargs)
 
 
 def ok(response):
@@ -120,7 +128,7 @@ def compute_down(expr, ec, **kwargs):
     tree = to_tree(expr)
 
     serial = ec.serial
-    r = get(
+    r = post(
         ec,
         'compute.{serial}'.format(serial=serial.name),
         data=serial.dumps({'expr': tree}),


### PR DESCRIPTION
verifies the cert by default; however, we want to disable this

Side note: we might want to think about making ssl the default. There is no downside really and it helps people who might not have thought about the fact that they will be streaming potentially sensitive data over the interned.

note: wait for #1172 and then change the .get to .post 