### PR TITLE
Pass the serialization format as a mimetype

### DIFF
--- a/blaze/server/client.py
+++ b/blaze/server/client.py
@@ -95,14 +95,28 @@ def discover(c):
     return c.dshape
 
 
+def mimetype(serial):
+    """Function to generate a blaze serialization format mimetype put into a
+    dictionary of headers for consumption by requests.
+
+    Examples
+    --------
+    >>> from blaze.server.serialization import msgpack
+    >>> mimetype(msgpack)
+    {'Content-Type': 'application/vnd.blaze+msgpack'}
+    """
+    return {'Content-Type': 'application/vnd.blaze+%s' % serial.name}
+
+
 @dispatch(Expr, Client)
 def compute_down(expr, ec, **kwargs):
     from .server import to_tree
     tree = to_tree(expr)
 
     serial = ec.serial
-    r = requests.post('%s/compute.%s' % (ec.url, serial.name),
-                      data=serial.dumps({'expr': tree}))
+    r = requests.post('%s/compute' % ec.url,
+                      data=serial.dumps({'expr': tree}),
+                      headers=mimetype(serial))
 
     if not ok(r):
         raise ValueError("Bad response: %s" % reason(r))

--- a/blaze/server/client.py
+++ b/blaze/server/client.py
@@ -37,7 +37,7 @@ def _request(method, client, url, params=None, **kwargs):
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', InsecureRequestWarning)
         return method(
-            '{base}/{url}'.format(
+            '{base}{url}'.format(
                 base=client.url,
                 url=url,
             ),
@@ -110,7 +110,7 @@ class Client(object):
     @property
     def dshape(self):
         """The datashape of the client"""
-        response = get(self, 'datashape')
+        response = get(self, '/datashape')
         if not ok(response):
             raise ValueError("Bad Response: %s" % reason(response))
 

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -327,7 +327,7 @@ def compserver():
     content_type = request.headers['content-type']
 
     try:
-        serial = _get_format(*mimetype_regex.match(content_type).groups())
+        serial = _get_format(mimetype_regex.match(content_type).groups()[0])
     except KeyError:
         return 'Unsupported serialization format', 415
 

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -325,11 +325,15 @@ mimetype_regex = re.compile(r'^application/vnd\.blaze\+(%s)$' %
 @crossdomain(origin='*', methods=['POST', 'HEAD', 'OPTIONS'])
 def compserver():
     content_type = request.headers['content-type']
+    matched = mimetype_regex.match(content_type)
+
+    if matched is None:
+        return 'Unsupported serialization format %s' % content_type, 415
 
     try:
-        serial = _get_format(mimetype_regex.match(content_type).groups()[0])
+        serial = _get_format(matched)
     except KeyError:
-        return 'Unsupported serialization format', 415
+        return 'Unsupported serialization format %s' % matched, 415
 
     try:
         payload = serial.loads(request.data)

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -331,7 +331,7 @@ def compserver():
         return 'Unsupported serialization format %s' % content_type, 415
 
     try:
-        serial = _get_format(matched)
+        serial = _get_format(matched.groups()[0])
     except KeyError:
         return 'Unsupported serialization format %s' % matched, 415
 

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -29,7 +29,7 @@ from blaze import compute
 from blaze.expr import utils as expr_utils
 from blaze.compute import compute_up
 
-from .serialization import json
+from .serialization import json, all_formats
 from ..interactive import InteractiveSymbol, coerce_scalar
 from ..expr import Expr, symbol
 
@@ -317,14 +317,17 @@ def from_tree(expr, namespace=None):
         return expr
 
 
+mimetype_regex = re.compile(r'^application/vnd\.blaze\+(%s)$' %
+                            '|'.join(x.name for x in all_formats))
+
+
 @api.route('/compute', methods=['POST', 'HEAD', 'OPTIONS'])
 @crossdomain(origin='*', methods=['POST', 'HEAD', 'OPTIONS'])
 def compserver():
     content_type = request.headers['content-type']
 
     try:
-        serial = _get_format(*re.match(r'^application/vnd\.blaze\+(.+)$',
-                                       content_type).groups())
+        serial = _get_format(*mimetype_regex.match(content_type).groups())
     except KeyError:
         return 'Unsupported serialization format', 404
 

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import socket
 import functools
+import re
 
 import flask
 from flask import Blueprint, Flask, request
@@ -316,12 +317,14 @@ def from_tree(expr, namespace=None):
         return expr
 
 
-@api.route('/compute.<serial_format>',
-           methods=['POST', 'HEAD', 'OPTIONS'])
+@api.route('/compute', methods=['POST', 'HEAD', 'OPTIONS'])
 @crossdomain(origin='*', methods=['POST', 'HEAD', 'OPTIONS'])
-def compserver(serial_format):
+def compserver():
+    content_type = request.headers['content-type']
+
     try:
-        serial = _get_format(serial_format)
+        serial = _get_format(*re.match(r'^application/vnd\.blaze\+(.+)$',
+                                       content_type).groups())
     except KeyError:
         return 'Unsupported serialization format', 404
 

--- a/blaze/server/server.py
+++ b/blaze/server/server.py
@@ -329,7 +329,7 @@ def compserver():
     try:
         serial = _get_format(*mimetype_regex.match(content_type).groups())
     except KeyError:
-        return 'Unsupported serialization format', 404
+        return 'Unsupported serialization format', 415
 
     try:
         payload = serial.loads(request.data)

--- a/docs/source/whatsnew/0.8.3.txt
+++ b/docs/source/whatsnew/0.8.3.txt
@@ -22,6 +22,11 @@ Improved Backends
 API Changes
 ~~~~~~~~~~~
 
+* Serialization format in blaze server is now passed in as a mimetype
+  (:issue:`1176`)
+* We only allow and use HTTP ``POST`` requests when sending a computation to
+  Blaze server for consistency with the HTTP spec (:issue:`1172`)
+
 Bug Fixes
 ~~~~~~~~~
 


### PR DESCRIPTION
the serialization format json, msgpack, etc is now passed as a vendor specific mime type instead of being part of the URL:

```python
requests.get('/compute',
             data=dict(expr=to_tree(expr)),
             headers={'Content-Type': 'application/vnd.blaze+json'})
```