### PR TITLE
Use builtins module not the implementation detail

### DIFF
--- a/blaze/server/spider.py
+++ b/blaze/server/spider.py
@@ -120,7 +120,7 @@ def _parse_args():
                    help='Host name. Use 0.0.0.0 to listen on all public IPs')
     p.add_argument('-l', '--follow-links', action='store_true',
                    help='Follow links when listing files')
-    p.add_argument('-e', '--ignored-exception', nargs='*',
+    p.add_argument('-e', '--ignored-exception', nargs='+',
                    default=['Exception'],
                    help='Exceptions to ignore when calling resource on a file')
     p.add_argument('-d', '--hidden', action='store_true',

--- a/blaze/server/spider.py
+++ b/blaze/server/spider.py
@@ -13,6 +13,11 @@ from odo.utils import ignoring
 
 from .server import Server, DEFAULT_PORT
 
+try:
+    import __builtin__ as builtins
+except ImportError:
+    import builtins
+
 
 __all__ = 'spider', 'from_yaml'
 
@@ -127,7 +132,7 @@ def _parse_args():
 
 def _main():
     args = _parse_args()
-    ignore = tuple(getattr(__builtins__, e) for e in args.ignored_exception)
+    ignore = tuple(getattr(builtins, e) for e in args.ignored_exception)
     resources = from_yaml(args.path,
                           ignore=ignore,
                           followlinks=args.follow_links,


### PR DESCRIPTION
closes #1181

also fixes an issue with `-e` not erroring out if no arguments were given to it